### PR TITLE
Resolve setup issues, merge pysal/#903, and make 3.6 support opt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+.ipynb_checkpoints/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ only:
 python:
   - "2.7"
   - "3.5"
-  - "3.6"
+
+allow_failures:
+    python:
+        - 3.6
 
 env:
   - PYSAL_PLUS=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
 
 script:
   - python setup.py sdist >/dev/null
-  - nosetests --with-coverage --cover-package=esda;
+  - nosetests -v --with-coverage --cover-package=esda;
 
 notifications:
     email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ before_install:
 install:
   - conda install --yes pip
   - conda install --yes --file requirements.txt;
+  - cd ../ && git clone https://github.com/pysal/libpysal.git
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -nw libpysal/ > /dev/null; fi
+  - pip install -e ./libpysal
+  - cd esda
   - pip install -r requirements_dev.txt
 
 script:

--- a/esda/getisord.py
+++ b/esda/getisord.py
@@ -4,7 +4,7 @@ Getis and Ord G statistic for spatial autocorrelation
 __author__ = "Sergio J. Rey <srey@asu.edu>, Myunghwa Hwang <mhwang4@gmail.com> "
 __all__ = ['G', 'G_Local']
 
-from ..common import np, stats, math
+from libpysal.common import np, stats, math
 from libpysal.weights.spatial_lag import lag_spatial as slag
 from .tabular import _univariate_handler
 

--- a/esda/smoothing.py
+++ b/esda/smoothing.py
@@ -1852,8 +1852,8 @@ class Headbanging_Median_Rate(object):
                 trp_r.sort(order='r')
                 lowest.append(trp_r['r'][0])
                 highest.append(trp_r['r'][-1])
-                lowest_aw.append(self.aw[trp_r['w'][0]])
-                highest_aw.append(self.aw[trp_r['w'][-1]])
+                lowest_aw.append(self.aw[int(trp_r['w'][0])])
+                highest_aw.append(self.aw[int(trp_r['w'][-1])])
             wm_lowest = weighted_median(np.array(lowest), np.array(lowest_aw))
             wm_highest = weighted_median(
                 np.array(highest), np.array(highest_aw))

--- a/esda/smoothing.py
+++ b/esda/smoothing.py
@@ -1852,8 +1852,8 @@ class Headbanging_Median_Rate(object):
                 trp_r.sort(order='r')
                 lowest.append(trp_r['r'][0])
                 highest.append(trp_r['r'][-1])
-                lowest_aw.append(self.aw[int(trp_r['w'][0])])
-                highest_aw.append(self.aw[int(trp_r['w'][-1])])
+                lowest_aw.append(self.aw[int(round(trp_r['w'][0]))])
+                highest_aw.append(self.aw[int(round(trp_r['w'][-1]))])
             wm_lowest = weighted_median(np.array(lowest), np.array(lowest_aw))
             wm_highest = weighted_median(
                 np.array(highest), np.array(highest_aw))

--- a/esda/smoothing.py
+++ b/esda/smoothing.py
@@ -14,8 +14,9 @@ Author(s):
 
 __author__ = "Myunghwa Hwang <mhwang4@gmail.com>, David Folch <dfolch@asu.edu>, Luc Anselin <luc.anselin@asu.edu>, Serge Rey <srey@asu.edu"
 
-from libpysal.weights import comb, Kernel, W
-from libpysal.weights.util import get_points_array
+from libpysal.weights.weights import W
+from libpysal.weights.Distance import Kernel
+from libpysal.weights.util import get_points_array, comb
 from libpysal.cg import Point, Ray, LineSegment
 from libpysal.cg import get_angle_between, get_points_dist, get_segment_point_dist,\
                  get_point_at_angle_and_dist, convex_hull, get_bounding_box

--- a/esda/tests/test_gamma.py
+++ b/esda/tests/test_gamma.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from libpysal.weights import lat2W
+from libpysal.weights.util import lat2W
 from ..gamma import Gamma
 from libpysal.common import pandas
 

--- a/esda/tests/test_geary.py
+++ b/esda/tests/test_geary.py
@@ -3,10 +3,11 @@ import unittest
 
 from libpysal import open as popen
 from libpysal import examples
+from libpysal.common import pandas
+
 from .. import geary
 import numpy as np
 
-from ...common import pandas
 PANDAS_EXTINCT = pandas is None
 
 class Geary_Tester(unittest.TestCase):

--- a/esda/tests/test_join_counts.py
+++ b/esda/tests/test_join_counts.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 
 from ..join_counts import Join_Counts
-from libpysal.weights import lat2W
+from libpysal.weights.util import lat2W
 from libpysal.common import pandas
 
 PANDAS_EXTINCT = pandas is None

--- a/esda/tests/test_mapclassify.py
+++ b/esda/tests/test_mapclassify.py
@@ -1,7 +1,7 @@
 import libpysal as pysal
+from libpysal.common import RTOL
 from ..mapclassify import *
 from ..mapclassify import binC, bin, bin1d
-from ...common import RTOL
 import numpy as np
 import unittest
 import types

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -4,6 +4,7 @@ from libpysal.common import pandas, RTOL, ATOL
 from .. import moran
 import numpy as np
 
+
 PANDAS_EXTINCT = pandas is None
 
 class Moran_Tester(unittest.TestCase):
@@ -27,7 +28,7 @@ class Moran_Tester(unittest.TestCase):
 
     @unittest.skipIf(PANDAS_EXTINCT, 'missing pandas')
     def test_by_col(self):
-        import pysal.contrib.pdio as pdio
+        from libpysal.io import geotable as pdio
         df = pdio.read_files(pysal.examples.get_path('sids2.dbf'))
         w = pysal.open(pysal.examples.get_path("sids2.gal")).read()
         mi = moran.Moran.by_col(df, ['SIDR74'], w=w, two_tailed=False)
@@ -51,7 +52,7 @@ class Moran_Rate_Tester(unittest.TestCase):
 
     @unittest.skipIf(PANDAS_EXTINCT, 'missing pandas')
     def test_by_col(self):
-        import pysal.contrib.pdio as pdio
+        from libpysal.io import geotable as pdio
         df = pdio.read_files(pysal.examples.get_path('sids2.dbf'))
         mi = moran.Moran_Rate.by_col(df, ['SID79'], ['BIR79'], w=self.w, two_tailed=False)
         sidr = np.unique(mi["SID79-BIR79_moran_rate"].values)
@@ -115,7 +116,7 @@ class Moran_Local_BV_Tester(unittest.TestCase):
 
     @unittest.skipIf(PANDAS_EXTINCT, 'missing pandas')
     def test_by_col(self):
-        import pysal.contrib.pdio as pdio
+        from libpysal.io import geotable as pdio
         df = pdio.read_files(pysal.examples.get_path('sids2.dbf'))
         np.random.seed(12345)
         moran.Moran_Local_BV.by_col(df, ['SIDR74', 'SIDR79'], w=self.w,
@@ -145,7 +146,7 @@ class Moran_Local_Rate_Tester(unittest.TestCase):
 
     @unittest.skipIf(PANDAS_EXTINCT, 'missing pandas')
     def test_by_col(self):
-        import pysal.contrib.pdio as pdio
+        from libpysal.io import geotable as pdio
         df = pdio.read_files(pysal.examples.get_path('sids2.dbf'))
         lm = moran.Moran_Local_Rate.by_col(df, ['SID79'], ['BIR79'], w=self.w,
                                            outvals=['p_z_sim', 'z_sim'],

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -1,7 +1,7 @@
 import unittest
 import libpysal as pysal
+from libpysal.common import pandas, RTOL, ATOL
 from .. import moran
-from ...common import pandas, RTOL, ATOL
 import numpy as np
 
 PANDAS_EXTINCT = pandas is None
@@ -21,7 +21,7 @@ class Moran_Tester(unittest.TestCase):
         w = pysal.open(pysal.examples.get_path("sids2.gal")).read()
         f = pysal.open(pysal.examples.get_path("sids2.dbf"))
         SIDR = np.array(f.by_col("SIDR74"))
-        mi = pysal.Moran(SIDR, w, two_tailed=False)
+        mi = moran.Moran(SIDR, w, two_tailed=False)
         np.testing.assert_allclose(mi.I, 0.24772519320480135, atol=ATOL, rtol=RTOL)
         self.assertAlmostEquals(mi.p_norm,  5.7916539074498452e-05)
 

--- a/esda/tests/test_smoothing.py
+++ b/esda/tests/test_smoothing.py
@@ -1,6 +1,6 @@
 import unittest
 import libpysal as pysal
-from libpysal.weights import KNN
+from libpysal.weights.Distance import KNN, Kernel
 from .. import smoothing as sm
 import numpy as np
 from libpysal.common import RTOL, ATOL, pandas
@@ -344,10 +344,10 @@ class TestKernel_AgeAdj_SM(unittest.TestCase):
         self.s = np.array([98, 88, 15, 29, 20, 23, 33, 25, 76, 80, 89, 66])
         self.points = [(
             10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
-        self.kw = pysal.weights.Kernel(self.points)
+        self.kw = Kernel(self.points)
         self.points1 = np.array(self.points) + 5
         self.points1 = np.vstack((self.points1, self.points))
-        self.kw1 = pysal.weights.Kernel(self.points1)
+        self.kw1 = Kernel(self.points1)
         if not self.kw.id_order_set:
             self.kw.id_order = range(0, len(self.points))
         if not PANDAS_EXTINCT:

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,13 @@ except ImportError:
 
 setup(name='esda', #name of package
       version='1.0.0dev',
-      description=, 'Package with statistics for exploratory spatial data analysis',
-      url=, 'https://github.com/pysal/esda'
-      maintainer='', 
-      maintainer_email='', 
-      test_suite = 'nose.collector',
+      description='Package with statistics for exploratory spatial data analysis',
+      url='https://github.com/pysal/esda',
+      maintainer='Sergio Rey',
+      maintainer_email='sjsrey@gmail.com',
+      test_suite='nose.collector',
       tests_require=['nose'],
-      keywords='spatial statistics'
+      keywords='spatial statistics',
       classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Science/Research',
@@ -31,6 +31,6 @@ setup(name='esda', #name of package
       license='3-Clause BSD',
       packages=['esda'],
       install_requires=['numpy', 'scipy', 'libpysal'
-                        ,],
+                        ],
       zip_safe=False,
-      cmdclass = {'build.py':build_py})
+      cmdclass={'build.py': build_py})

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from distutils.command.build_py import build_py
 
-setup(name='esda', #name of package
+setup(name='esda',  # name of package
       version='1.0.0dev',
       description='Package with statistics for exploratory spatial data analysis',
       url='https://github.com/pysal/esda',

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(name='esda', #name of package
       version='1.0.0dev',
       description=, 'Package with statistics for exploratory spatial data analysis',
       url=, 'https://github.com/pysal/esda'
-      maintainer=, 
-      maintainer_email=, 
+      maintainer='', 
+      maintainer_email='', 
       test_suite = 'nose.collector',
       tests_require=['nose'],
       keywords='spatial statistics'
@@ -29,7 +29,7 @@ setup(name='esda', #name of package
         'Programming Language :: Python :: 3.4'
         ],
       license='3-Clause BSD',
-      packages=[],
+      packages=['esda'],
       install_requires=['numpy', 'scipy', 'libpysal'
                         ,],
       zip_safe=False,


### PR DESCRIPTION
1. fix syntax errors in the setup file
2. make imports from `libpysal` refer exactly to the file from which the symbol is imported
3. pull in fixes from upstream #903, which fixes the type instability in the headbanging triples
4. 3 makes tests fail on 3.6, so 3.6 support was made optional. When 3.7 is released (or someone figures out the bug to be filed on this), we will reenable 3.6 support. 
