### PR TITLE
`.z` attribute divided by standard deviation

### DIFF
--- a/esda/moran.py
+++ b/esda/moran.py
@@ -171,6 +171,10 @@ class Moran(object):
             else:
                 self.p_z_sim = stats.norm.cdf(self.z_sim)
 
+        # provide .z attribute that is znormalized
+        sy = y.std()
+        self.z /= sy
+        
     def __moments(self):
         self.n = len(self.y)
         y = self.y
@@ -201,10 +205,6 @@ class Moran(object):
         VIR = (A - B) / ((n - 1) * (n - 2) * (n - 3 ) * s02) - EI*EI
         self.VI_rand = VIR 
         self.seI_rand = VIR ** (1 / 2.)
-
-
-
-
 
     def __calc(self, z):
         zl = slag(self.w, z)
@@ -366,6 +366,8 @@ class Moran_BV(object):
         y = np.asarray(y).flatten()
         zy = (y - y.mean()) / y.std(ddof=1)
         zx = (x - x.mean()) / x.std(ddof=1)
+        self.y = y
+        self.x = x
         self.zx = zx
         self.zy = zy
         n = x.shape[0]
@@ -1044,6 +1046,7 @@ class Moran_Local_BV(object):
         x = np.asarray(x).flatten()
         y = np.asarray(y).flatten()
         self.y = y
+        self.x =x
         n = len(y)
         self.n = n
         self.n_1 = n - 1

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -32,6 +32,13 @@ class Moran_Tester(unittest.TestCase):
         mi = moran.Moran(y, w, transformation='B')
         np.testing.assert_allclose(mi.VI_rand, 0.059687500000000004, atol=ATOL, rtol=RTOL)
         np.testing.assert_allclose(mi.VI_norm, 0.053125000000000006, atol=ATOL, rtol=RTOL)
+    
+    def test_z_consistency(self):
+        m1 = moran.Moran(self.y, self.w)
+        # m2 = moran.Moran_BV(self.x, self.y, self.w) TODO testing for other.z values
+        m3 = moran.Moran_Local(self.y, self.w)
+        # m4 = moran.Moran_Local_BV(self.x, self.y, self.w)
+        np.testing.assert_allclose(m1.z, m3.z, atol=ATOL, rtol=RTOL)
  
 
     @unittest.skipIf(PANDAS_EXTINCT, 'missing pandas')


### PR DESCRIPTION
In order to allow for the option zstandard in `splot.esda` visualisations `esda.moran` Objects need to commonly provide input .x, .y and standardised .zx, .zy attributes.

The following were implemented:

 *  esda.moran.Moran: .z attribute is divided by standard deviation
  * esda.moran.Moran_BV: has non-standardised .x and .y values (input parameters)
 *  esda.moran.Moran_Local_BV: has non-standardised .x and .y values (input parameters)

additionally I wrote a test function `test_z_consistency` to test the consistency of the `.z` value over different `esda.moran` objects