### PR TITLE
move api into __init__ and remove api

### DIFF
--- a/esda/__init__.py
+++ b/esda/__init__.py
@@ -3,9 +3,10 @@
 =================================================
 
 """
-from . import moran
-from . import smoothing
-from . import getisord
-from . import geary
-from . import join_counts
-from . import gamma
+from .moran import (Moran, Moran_BV, Moran_BV_matrix,
+                    Moran_Local, Moran_Local_BV, 
+                    Moran_Rate, Moran_Local_Rate)
+from .getisord import G, G_Local
+from .geary import Geary
+from .join_counts import Join_Counts
+from .gamma import Gamma

--- a/esda/api.py
+++ b/esda/api.py
@@ -1,4 +1,0 @@
-from .moran import Moran, Moran_Local
-from .geary import Geary
-from .getisord import G, G_Local
-from .join_counts import Join_Counts


### PR DESCRIPTION
This rearranges functionality in the module to expose all user classes at top level. 