### PR TITLE
BUG: EG_Sim and seG_sim were incorrectly given as scalars. #53

### DIFF
--- a/esda/getisord.py
+++ b/esda/getisord.py
@@ -297,7 +297,7 @@ class G_Local(object):
 
     >>> w = libpysal.weights.DistanceBand(points,threshold=15)
 
-    Prepareing a variable
+    Preparing a variable
 
     >>> y = numpy.array([2, 3, 3.2, 5, 8, 7])
 
@@ -313,6 +313,10 @@ class G_Local(object):
             1.77833941])
     >>> round(lg.p_sim[0], 3)
     0.101
+
+    p-value based on standard normal approximation from permutations
+    >>> round(lg.p_z_sim[0], 3)
+    0.154
 
     >>> numpy.random.seed(10)
 
@@ -373,8 +377,8 @@ class G_Local(object):
             larger[low_extreme] = self.permutations - larger[low_extreme]
             self.p_sim = (larger + 1.0) / (permutations + 1)
             self.sim = sim
-            self.EG_sim = sim.mean()
-            self.seG_sim = sim.std()
+            self.EG_sim = sim.mean(axis=0)
+            self.seG_sim = sim.std(axis=0)
             self.VG_sim = self.seG_sim * self.seG_sim
             self.z_sim = (self.Gs - self.EG_sim) / self.seG_sim
             self.p_z_sim = 1 - stats.norm.cdf(np.abs(self.z_sim))

--- a/esda/tests/test_getisord.py
+++ b/esda/tests/test_getisord.py
@@ -47,6 +47,7 @@ class G_Local_Tester(unittest.TestCase):
         lg = getisord.G_Local(self.y, self.w, transform='B')
         self.assertAlmostEqual(lg.Zs[0], -1.0136729, places=7)
         self.assertAlmostEqual(lg.p_sim[0], 0.10100000000000001, places=7)
+        self.assertAlmostEqual(lg.p_z_sim[0], 0.154373052, places=7)
 
     def test_G_Local_Row_Standardized(self):
         lg = getisord.G_Local(self.y, self.w, transform='R')


### PR DESCRIPTION
- Use a vector of expectations and standard errors rather than scalars when approximating the local normal distributions based on permutations
- More tests and typo corrections.