### PR TITLE
(bug) fix docs build

### DIFF
--- a/esda/getisord.py
+++ b/esda/getisord.py
@@ -174,8 +174,8 @@ class G(object):
         """
         Function to compute a G statistic on a dataframe
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         df          :   pandas.DataFrame
                         a pandas dataframe with a geometry column
         cols        :   string or list of string

--- a/esda/getisord.py
+++ b/esda/getisord.py
@@ -491,10 +491,6 @@ class G_Local(object):
                         in memory. Otherwise, returns a copy of the dataframe with
                         the relevant columns attached.
 
-        See Also
-        ---------
-        For further documentation, refer to the G_Local class in esda
-        
         """
         return _univariate_handler(df, cols, w=w, inplace=inplace, pvalue=pvalue,
                                    outvals=outvals, stat=cls,

--- a/esda/getisord.py
+++ b/esda/getisord.py
@@ -202,9 +202,6 @@ class G(object):
         If inplace, None, and operation is conducted on dataframe in memory. Otherwise,
         returns a copy of the dataframe with the relevant columns attached.
 
-        See Also
-        ---------
-        For further documentation, refer to the G class in pysal.esda
         """
         return _univariate_handler(df, cols, w=w, inplace=inplace, pvalue=pvalue,
                                    outvals=outvals, stat=cls,

--- a/esda/getisord.py
+++ b/esda/getisord.py
@@ -494,6 +494,7 @@ class G_Local(object):
         See Also
         ---------
         For further documentation, refer to the G_Local class in esda
+        
         """
         return _univariate_handler(df, cols, w=w, inplace=inplace, pvalue=pvalue,
                                    outvals=outvals, stat=cls,

--- a/esda/getisord.py
+++ b/esda/getisord.py
@@ -486,12 +486,14 @@ class G_Local(object):
 
         Returns
         --------
-        If inplace, None, and operation is conducted on dataframe in memory. Otherwise,
-        returns a copy of the dataframe with the relevant columns attached.
+        pandas.DataFrame
+                        If inplace, None, and operation is conducted on dataframe
+                        in memory. Otherwise, returns a copy of the dataframe with
+                        the relevant columns attached.
 
         See Also
         ---------
-        For further documentation, refer to the G_Local class in pysal.esda
+        For further documentation, refer to the G_Local class in esda
         """
         return _univariate_handler(df, cols, w=w, inplace=inplace, pvalue=pvalue,
                                    outvals=outvals, stat=cls,

--- a/esda/getisord.py
+++ b/esda/getisord.py
@@ -461,8 +461,8 @@ class G_Local(object):
         """
         Function to compute a G_Local statistic on a dataframe
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         df          :   pandas.DataFrame
                         a pandas dataframe with a geometry column
         cols        :   string or list of string
@@ -485,7 +485,7 @@ class G_Local(object):
                         documentation for the G_Local statistic.
 
         Returns
-        --------
+        -------
         pandas.DataFrame
                         If inplace, None, and operation is conducted on dataframe
                         in memory. Otherwise, returns a copy of the dataframe with

--- a/esda/join_counts.py
+++ b/esda/join_counts.py
@@ -201,9 +201,6 @@ class Join_Counts(object):
         If inplace, None, and operation is conducted on dataframe in memory. Otherwise,
         returns a copy of the dataframe with the relevant columns attached.
 
-        See Also
-        ---------
-        For further documentation, refer to the Join_Count class in pysal.esda
         """
         if outvals is None:
             outvals = []

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -452,9 +452,6 @@ class Moran_BV(object):
         If inplace, None, and operation is conducted on dataframe in memory. Otherwise,
         returns a copy of the dataframe with the relevant columns attached.
 
-        See Also
-        ---------
-        For further documentation, refer to the Moran_BV class in pysal.esda
         """
         return _bivariate_handler(df, x, y=y, w=w, inplace=inplace,
                                   pvalue = pvalue, outvals = outvals,

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -255,9 +255,6 @@ class Moran(object):
         If inplace, None, and operation is conducted on dataframe in memory. Otherwise,
         returns a copy of the dataframe with the relevant columns attached.
 
-        See Also
-        ---------
-        For further documentation, refer to the Moran class in pysal.esda
         """
         return _univariate_handler(df, cols, w=w, inplace=inplace, pvalue=pvalue,
                                    outvals=outvals, stat=cls,
@@ -713,9 +710,6 @@ class Moran_Rate(Moran):
         If inplace, None, and operation is conducted on dataframe in memory. Otherwise,
         returns a copy of the dataframe with the relevant columns attached.
 
-        See Also
-        ---------
-        For further documentation, refer to the Moran_Rate class in pysal.esda
         """
         if not inplace:
             new = df.copy()
@@ -978,9 +972,6 @@ class Moran_Local(object):
         If inplace, None, and operation is conducted on dataframe in memory. Otherwise,
         returns a copy of the dataframe with the relevant columns attached.
 
-        See Also
-        ---------
-        For further documentation, refer to the Moran_Local class in pysal.esda
         """
         return _univariate_handler(df, cols, w=w, inplace=inplace, pvalue=pvalue,
                                    outvals=outvals, stat=cls,
@@ -1224,9 +1215,6 @@ class Moran_Local_BV(object):
         If inplace, None, and operation is conducted on dataframe in memory. Otherwise,
         returns a copy of the dataframe with the relevant columns attached.
 
-        See Also
-        ---------
-        For further documentation, refer to the Moran_Local_BV class in pysal.esda
         """
         return _bivariate_handler(df, x, y=y, w=w, inplace=inplace,
                                   pvalue = pvalue, outvals = outvals,
@@ -1380,9 +1368,6 @@ class Moran_Local_Rate(Moran_Local):
         If inplace, None, and operation is conducted on dataframe in memory. Otherwise,
         returns a copy of the dataframe with the relevant columns attached.
 
-        See Also
-        ---------
-        For further documentation, refer to the Moran_Local_Rate class in pysal.esda
         """
         if not inplace:
             new = df.copy()


### PR DESCRIPTION
This PR is to fix the doc building bug https://github.com/pysal/esda/issues/55

It turns out that [some docstrings in `esda` under the `See Also` section](https://github.com/pysal/esda/blob/master/esda/moran.py#L258) do not meet [the requirement as defined in numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#sections). 

After deleting the sections `See Also` (I do not see them particularly necessary here), the docs build fine.
