### PR TITLE
ENH - Join count tails

### DIFF
--- a/esda/join_counts.py
+++ b/esda/join_counts.py
@@ -195,7 +195,7 @@ class Join_Counts(object):
 
             stat = ((self.autocorr_pos - np.mean(self.sim_autocurr_pos))**2 +
                                               (self.autocorr_neg - np.mean(self.sim_autocurr_neg))**2)
-            self.sim_autocorr_chi2 = chi2.cdf(1 - stat, 1)
+            self.sim_autocorr_chi2 = 1 - chi2.cdf(stat, 1)
 
             p_sim_bb = self.__pseudop(self.sim_bb, self.bb)
             p_sim_bw = self.__pseudop(self.sim_bw, self.bw)

--- a/esda/join_counts.py
+++ b/esda/join_counts.py
@@ -188,13 +188,19 @@ class Join_Counts(object):
             self.min_bw = np.min(self.sim_bw)
             self.mean_bw = np.mean(self.sim_bw)
             self.max_bw = np.max(self.sim_bw)
+            self.sim_autocurr_pos = sim_jc[:, 0]+sim_jc[:, 1]
+            self.sim_autocurr_neg = sim_jc[:, 2]
             self.sim_chi2 = sim_jc[:, 3]
             p_sim_bb = self.__pseudop(self.sim_bb, self.bb)
             p_sim_bw = self.__pseudop(self.sim_bw, self.bw)
             p_sim_chi2 = self.__pseudop(self.sim_chi2, self.chi2)
+            p_sim_autocorr_pos = self.__pseudop(self.sim_autocurr_pos, self.autocorr_pos)
+            p_sim_autocorr_neg = self.__pseudop(self.sim_autocurr_neg, self.autocorr_neg)
             self.p_sim_bb = p_sim_bb
             self.p_sim_bw = p_sim_bw
             self.p_sim_chi2 = p_sim_chi2
+            self.p_sim_autocorr_pos = p_sim_autocorr_pos
+            self.p_sim_autocorr_neg = p_sim_autocorr_neg
 
     def __calc(self, z):
         adj_list = self.adj_list

--- a/esda/join_counts.py
+++ b/esda/join_counts.py
@@ -7,6 +7,7 @@ __author__ = "Sergio J. Rey <srey@asu.edu> , Luc Anselin <luc.anselin@asu.edu>"
 from libpysal.weights.spatial_lag import lag_spatial
 from .tabular import _univariate_handler
 from scipy.stats import chi2_contingency
+from scipy.stats import chi2
 import numpy as np
 import pandas as pd
 
@@ -191,6 +192,11 @@ class Join_Counts(object):
             self.sim_autocurr_pos = sim_jc[:, 0]+sim_jc[:, 1]
             self.sim_autocurr_neg = sim_jc[:, 2]
             self.sim_chi2 = sim_jc[:, 3]
+
+            stat = ((self.autocorr_pos - np.mean(self.sim_autocurr_pos))**2 +
+                                              (self.autocorr_neg - np.mean(self.sim_autocurr_neg))**2)
+            self.sim_autocorr_chi2 = chi2.cdf(1 - stat, 1)
+
             p_sim_bb = self.__pseudop(self.sim_bb, self.bb)
             p_sim_bw = self.__pseudop(self.sim_bw, self.bw)
             p_sim_chi2 = self.__pseudop(self.sim_chi2, self.chi2)

--- a/esda/join_counts.py
+++ b/esda/join_counts.py
@@ -153,6 +153,9 @@ class Join_Counts(object):
         self.chi2 = results[3]
         self.chi2_p = results[4]
         self.chi2_dof = results[5]
+        self.autocorr_pos = self.bb + self.ww
+        self.autocorr_neg = self.bw
+
         crosstab = pd.DataFrame(data=results[-1])
         id_names = ['W', 'B']
         idx = pd.Index(id_names, name='Focal')

--- a/esda/join_counts.py
+++ b/esda/join_counts.py
@@ -133,7 +133,6 @@ class Join_Counts(object):
     >>> jc.p_sim_chi2
     0.002
 
-
     Notes
     -----
     Technical details and derivations can be found in :cite:`cliff81`.
@@ -193,8 +192,8 @@ class Join_Counts(object):
             self.sim_autocurr_neg = sim_jc[:, 2]
             self.sim_chi2 = sim_jc[:, 3]
 
-            stat = ((self.autocorr_pos - np.mean(self.sim_autocurr_pos))**2 +
-                                              (self.autocorr_neg - np.mean(self.sim_autocurr_neg))**2)
+            stat = ((self.autocorr_pos - np.mean(self.sim_autocurr_pos))**2 / np.mean(self.sim_autocurr_pos)**2 +
+                                              (self.autocorr_neg - np.mean(self.sim_autocurr_neg))**2 / np.mean(self.sim_autocurr_pos)**2)
             self.sim_autocorr_chi2 = 1 - chi2.cdf(stat, 1)
 
             p_sim_bb = self.__pseudop(self.sim_bb, self.bb)

--- a/esda/tests/test_join_counts.py
+++ b/esda/tests/test_join_counts.py
@@ -21,6 +21,8 @@ class Join_Counts_Tester(unittest.TestCase):
         self.assertAlmostEqual(jc.bb, 10.0)
         self.assertAlmostEqual(jc.bw, 4.0)
         self.assertAlmostEqual(jc.ww, 10.0)
+        self.assertAlmostEqual(jc.autocorr_neg, 4.0)  # jc.bw
+        self.assertAlmostEqual(jc.autocorr_pos, 20.0)
         self.assertAlmostEqual(jc.J, 24.0)
         self.assertAlmostEqual(len(jc.sim_bb), 999)
         self.assertAlmostEqual(jc.p_sim_bb, 0.0030000000000000001)
@@ -41,7 +43,7 @@ class Join_Counts_Tester(unittest.TestCase):
         import pandas as pd
         df = pd.DataFrame(self.y, columns=['y'])
         np.random.seed(12345)
-        r1 = Join_Counts.by_col(df, ['y'], w=self.w, permutations=999)
+        r1 = Join_Counts.by_col(df, ['y'], w=self.w, permutations=999)  # outvals = ['bb', 'bw', 'ww', 'p_sim_bw', 'p_sim_bb']
 
         bb = np.unique(r1.y_bb.values)
         bw = np.unique(r1.y_bw.values)

--- a/esda/tests/test_join_counts.py
+++ b/esda/tests/test_join_counts.py
@@ -37,6 +37,9 @@ class Join_Counts_Tester(unittest.TestCase):
         self.assertAlmostEqual(8.479632255856034, jc.chi2)
         self.assertAlmostEqual(0.003591446953916693, jc.chi2_p)
         self.assertAlmostEqual(0.002, jc.p_sim_chi2)
+        self.assertAlmostEqual(1.0, jc.p_sim_autocorr_neg)
+        self.assertAlmostEqual(0.001, jc.p_sim_autocorr_pos)
+        self.assertAlmostEqual(0.000, jc.sim_autocorr_chi2)
 
     @unittest.skipIf(PANDAS_EXTINCT, 'missing pandas')
     def test_by_col(self):

--- a/esda/tests/test_join_counts.py
+++ b/esda/tests/test_join_counts.py
@@ -39,7 +39,7 @@ class Join_Counts_Tester(unittest.TestCase):
         self.assertAlmostEqual(0.002, jc.p_sim_chi2)
         self.assertAlmostEqual(1.0, jc.p_sim_autocorr_neg)
         self.assertAlmostEqual(0.001, jc.p_sim_autocorr_pos)
-        self.assertAlmostEqual(0.000, jc.sim_autocorr_chi2)
+        self.assertAlmostEqual(0.2653504320039377, jc.sim_autocorr_chi2)
 
     @unittest.skipIf(PANDAS_EXTINCT, 'missing pandas')
     def test_by_col(self):


### PR DESCRIPTION
In response to https://github.com/pysal/esda/issues/48.

1. Added autocorr_neg and autocorr_pos as instance attributes to Join_Counts class
2. Added relevant tests to the Join_Counts_Tester class

Will create a separate branch on my fork / fork off my fork to update the docs associated with Join_Counts