### PR TITLE
DOC: fixing link in geosilhouettes notebook

### DIFF
--- a/notebooks/geosilhouettes.ipynb
+++ b/notebooks/geosilhouettes.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Geosilhouettes: geographical measures of cluster fit\n",
     "\n",
-    "[Silhouette statistics](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.silhouette_samples.html) [(Rousseeuw, 1987)](https://doi.org/10.1016/0377-0427(87)90125-7)) are a nonparametric measure of an observation's goodness of fit to a given cluster. Where clusters have a *geographical* interpretation, such as when they represent geographical regions, silhouette statistics can incorporate *spatial thinking* in order to provide more useful measures of cluster fit.   The [paper by Wolf, Knaap, & Rey (2019)](https://doi.org/10.1177%2F2399808319875752).\n",
+    "[Silhouette statistics](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.silhouette_samples.html) (<a href=\"https://doi.org/10.1016/0377-0427(87)90125-7\">Rousseeuw, 1987</a>) are a nonparametric measure of an observation's goodness of fit to a given cluster. Where clusters have a *geographical* interpretation, such as when they represent geographical regions, silhouette statistics can incorporate *spatial thinking* in order to provide more useful measures of cluster fit.   The [paper by Wolf, Knaap, & Rey (2019)](https://doi.org/10.1177%2F2399808319875752).\n",
     "([preprint on SocArXiv](https://osf.io/preprints/socarxiv/vd3uk/)) defines two:\n",
     "\n",
     "1. **Path Silhouettes**, which characterize the joint geographical and feature similarity in a clustering.\n",
@@ -878,7 +878,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Parentheses in the DOI url for Rousseeuw 1987 paper caused the link to render incorrectly on Github preview of notebook and resulted in a dead link. Reformatted link to render properly and direct to the paper.