### PR TITLE
[WIP]: initial commit of ripley in numpy-oriented style

### DIFF
--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -34,7 +34,7 @@ def _(shape: numpy.ndarray):
     If a shape describes a bounding box, compute length times width
     """
     assert len(shape) == 4, "shape is not a bounding box!"
-    width, height = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    width, height = shape[2] - shape[0], shape[3] - shape[1]
     return numpy.abs(width * height)
 
 
@@ -228,7 +228,10 @@ def _prepare(coordinates, support, distances, metric, hull, edge_correction):
         support = 20
 
     if isinstance(support, int):
-        support = numpy.linspace(0, distances.max(), num=support)
+        bbox = _bbox(coordinates)
+        height, width = bbox[3] - bbox[1], bbox[2] - bbox[0]
+        ripley_rule = 0.25 * numpy.minimum(height, width)
+        support = numpy.linspace(0, ripley_rule, num=support)
     elif isinstance(support, tuple):
         if len(support) == 1:
             support = numpy.linspace(0, support[0], num=20)  # default support n bins

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -486,6 +486,8 @@ def k_function(
                 f" matrix matching the number of input points. The shape of the input matrix"
                 f" is {distance.shape}, but required shape is ({upper_tri_n},) or ({n},{n})"
             )
+    else:
+        upper_tri_distances = spatial.distance.pdist(coordinates, metric=metric)
     n_pairs_less_than_d = (upper_tri_distances < support.reshape(-1, 1)).sum(axis=1)
     intensity = n / _area(hull)
     k_estimate = ((n_pairs_less_than_d * 2) / n) / intensity

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -130,8 +130,6 @@ try:
     import pygeos
 
     HAS_PYGEOS = True
-except ModuleNotFoundError:
-    HAS_PYGEOS = False
 
     @_area.register
     def _(shape: pygeos.Geometry):
@@ -156,6 +154,10 @@ except ModuleNotFoundError:
         then use pygeos.bounds
         """
         return pygeos.bounds(shape)
+
+
+except ModuleNotFoundError:
+    HAS_PYGEOS = False
 
 
 def _build_best_tree(coordinates, metric):

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -458,7 +458,7 @@ def k_function(
             )
     n_pairs_less_than_d = (upper_tri_distances < support.reshape(-1, 1)).sum(axis=1)
     intensity = n / _area(hull)
-    k_estimate = n_pairs_less_than_d * 2 / intensity
+    k_estimate = ((n_pairs_less_than_d * 2) / n) / intensity
     return support, kestimate
 
 

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -1,5 +1,4 @@
 import numpy
-import numba
 import warnings
 from scipy import spatial, interpolate
 from typing import Union, Any

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -411,7 +411,7 @@ def g_function(coordinates, support=None, distances=None, metric="euclidean"):
     if isinstance(coordinates, (spatial.KDTree, spatial.cKDTree)):
         tree = coordinates
         coordinates = tree.data
-    coordinates, support, distances, metric = _prepare(
+    coordinates, support, distances, metric, *_ = _prepare(
         coordinates, support, distances, metric, None, None
     )
     if distances is not None:

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -1,0 +1,663 @@
+import numpy
+import numba
+import warnings
+from scipy import spatial, interpolate
+from typing import Union, Any
+from functools import singledispatch
+from collections import namedtuple
+from libpysal.cg import alpha_shape_auto, Arc_KDTree
+
+### Utilities and dispatching
+
+TREE_TYPES = (spatial.KDTree, spatial.cKDTree, Arc_KDTree)
+try:
+    from sklearn.neighbors import KDTree, BallTree
+
+    TREE_TYPES = (*TREE_TYPES, KDTree, BallTree)
+except ModuleNotFoundError:
+    pass
+
+## Define default dispatches and special dispatches without GEOS
+@singledispatch
+def _area(shape):
+    """
+    If a shape has an area attribute, return it. 
+    Works for: 
+        shapely.geometry.Polygon
+        scipy.spatial.ConvexHull
+    """
+    return shape.area
+
+
+@_area.register
+def _area(shape: Union[list, tuple, numpy.ndarray]):
+    """
+    If a shape describes a bounding box, compute length times width
+    """
+    assert len(shape) == 4, "shape is not a bounding box!"
+    width, height = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    return numpy.abs(width * height)
+
+
+@singledispatch
+def _bbox(shape):
+    """
+    If a shape has bounds, use those.
+    Works for:
+        shapely.geometry.Polygon
+    """
+    return shape.bounds
+
+
+@_bbox.register
+def _bbox(shape: numpy.array):
+    """
+    If a shape is an array of points, compute the minima/maxima
+    """
+    return numpy.array([*shape.min(axis=0), *shape.max(axis=0)])
+
+
+@_bbox.register
+def _bbox(shape: spatial.ConvexHull):
+    """
+    For scipy.spatial.ConvexHulls, compute the bounding box from
+    their boundary points.
+    """
+    return _bbox(shape.points[shape.vertices])
+
+
+@singledispatch
+def _within(x: float, y: float, shape: spatial.Delaunay):
+    """
+    For points and a delaunay triangulation, use the find_simplex
+    method to identify whether a point is inside the triangulation.
+
+    If the returned simplex index is -1, then the point is not
+    within a simplex of the triangulation. 
+    """
+    return delaunay.find_simplex((x, y)) > 0
+
+
+@_within.register
+def _within(x: float, y: float, shape: spatial.ConvexHull):
+    """
+    For convex hulls, convert them first. 
+    """
+    exterior = hull.points[hull.vertices]
+    delaunay = spatial.Delaunay(exterior)
+    return _within(x, y, delaunay)
+
+
+try:
+    import shapely
+
+    HAS_SHAPELY = True
+except ModuleNotFoundError:
+    HAS_SHAPELY = False
+
+    @_within.register
+    def _within(x: float, y: float, shape: shapely.geometry.Polygon):
+        """
+        If we know we're working with a shapely polygon, 
+        then use the contains method on the input shape. 
+        """
+        return shape.contains(shapely.geometry.Point((x, y)))
+
+
+try:
+    import pygeos
+
+    HAS_PYGEOS = True
+except ModuleNotFoundError:
+    HAS_PYGEOS = False
+
+    @_area.register
+    def _area(shape: pygeos.Geometry):
+        """
+        If we know we're working with a pygeos polygon, 
+        then use pygeos.area
+        """
+        return pygeos.area(shape)
+
+    @_within.register
+    def _within(x: float, y: float, shape: pygeos.Geometry):
+        """
+        If we know we're working with a pygeos polygon, 
+        then use pygeos.within
+        """
+        return pygeos.within(pygeos.points((x, y)), shape)
+
+    @_bbox.register
+    def _bbox(shape: pygeos.Geometry):
+        """
+        If we know we're working with a pygeos polygon, 
+        then use pygeos.bounds
+        """
+        return pygeos.bounds(shape)
+
+
+def _build_best_tree(coordinates, metric):
+    tree = scipy.spatial.cKDTree
+    try:
+        from sklearn.neighbors import KDTree, BallTree
+
+        if metric in KDTree.valid_metrics:
+            tree = lambda coordinates: KDTree(coordinates, metric=metric)
+        elif metric in BallTree.valid_metrics:
+            tree = lambda coordinates: BallTree(coordinates, metric=metric)
+        elif callable(metric):
+            warnings.Warn(
+                "Distance metrics defined in pure Python may "
+                " have unacceptable performance!"
+            )
+            tree = lambda coordinates: BallTree(coordinates, metric=metric)
+    except ModuleNotFoundError:
+        pass
+    return tree(coordinates)
+
+
+def _prepare_hull(coordinates, hull):
+    """
+    Construct a hull from the coordinates given a hull type
+    Will either return:
+        - a bounding box of [xmin, ymin, xmax, ymax]
+        - a scipy.spatial.ConvexHull object from the Qhull library
+        - a shapely shape using alpha_shape_auto
+    """
+    fail = True
+    if (hull is None) or (hull == "bbox"):
+        hull = numpy.asarray([*coordinates.min(axis=0), *coordinates.max(axis=0)])
+        fail = False
+    elif hull.startswith("convex"):
+        hull = spatial.ConvexHull(coordinates)
+        fail = False
+    elif hull.startswith("alpha") or hull.startswith("α"):
+        hull = alpha_shape_auto(coordinates)
+        fail = False
+    elif HAS_SHAPELY:  # protect the isinstance check if import has failed
+        if isinstance(hull, shapely.geometry.Polygon):
+            hull = hull
+            fail = False
+    elif HAS_PYGEOS:
+        if isinstance(hull, pygeos.Geometry):
+            hull = hull
+            fail = False
+    if fail:
+        raise ValueError(
+            "Hull type {hull} not in the set of valid options:"
+            '{None, "bbox", "convex", "alpha", "α", '
+            " shapely.geometry.Polygon, pygeos.Geometry}"
+        )
+    return hull
+
+
+def _prepare(coordinates, support, distances, metric, hull, edge_correction):
+
+    # Throw early if edge correction is requested
+    if edge_correction is not None:
+        raise NotImplementedError("Edge correction is not currently implemented.")
+
+    # cast to coordinate array
+    coordinates = numpy.asarray(coordinates)
+    hull = _prepare_hull(hull)
+
+    # evaluate distances
+    if (distances is None) and metric == "precomputed":
+        raise ValueError(
+            "If metric =`precomputed` then distances must"
+            " be provided as a (n,n) numpy array."
+        )
+    elif not (isinstance(metric, str) or callable(metric)):
+        raise TypeError(
+            f"`metric` argument must be callable or a string. Recieved: {metric}"
+        )
+    elif distances is not None and metric != "euclidean":
+        warnings.Warn(
+            "Distances were provided. The specified metric will be ignored."
+            " To use precomputed distances with a custom distance metric,"
+            " do not specify a `metric` argument."
+        )
+    elif isinstance(distances, numpy.ndarray):
+        assert (
+            distances.shape[0] == distances.shape[1] == coordinates.shape[0]
+        ), "Distances are not (n,n), aligned with coordinate matrix"
+
+    n = int(coordinates.shape[0])
+    upper_tri_n = int(n * (n - 1) * 0.5)
+
+    if support is None:
+        support = 20
+
+    if isinstance(support, int):
+        support = numpy.linspace(0, distances.max(), num=support)
+    elif isinstance(support, tuple):
+        if len(support) == 1:
+            support = numpy.linspace(0, support[0], num=20)  # default support n bins
+        elif len(support) == 2:
+            support = numpy.linspace(*support, num=20)  # default support n bins
+        elif len(support == 3):
+            support = numpy.linspace(support[0], support[1], num=support[2])
+    else:
+        try:
+            support = numpy.asarray(support)
+        except:
+            raise TypeError(
+                "`support` must be a tuple (either (start, stop, step), (start, stop) or (stop,)),"
+                " an int describing the number of breaks to use to evalute the function,"
+                " or an iterable containing the breaks to use to evaluate the function."
+                " Recieved object of type {}: {}".format(type(support), support)
+            )
+
+    return coordinates, support, distances, metric, hull, edge_correction
+
+
+### simulators
+
+
+def simulate(hull, intensity=None, size=None):
+    if (intensity is None) and (size is None):
+        intensity = 100 / _area(hull)  # default to intensity at 100 points per area
+        size = 1  # default to one replication
+
+    if isinstance(size, tuple):
+        if len(size) == 2 and intensity is None:
+            n_observations, n_replications = size
+            intensity = n_observations / _area(hull)
+        elif len(size) == 2 and intensity is not None:
+            raise ValueError(
+                "Either intensity or size as (n observations, n replications)"
+                " can be provided. Providing both creates statistical conflicts."
+                " between the requested intensity and implied intensity by"
+                " the number of observations and the area of the hull. If"
+                " you want to specify the intensity, use the intensity argument"
+                " and set size equal to the number of replications."
+            )
+        else:
+            raise ValueError(
+                f"Intensity and size not understood. Provide size as a tuple"
+                " containing (number of observations, number of replications)"
+                " with no specified intensity, or an intensity and size equal"
+                " to the number of replications."
+                " Recieved: `intensity={intensity}, size={size}`"
+            )
+
+    elif intensity is not None and isinstance(size, int):  # catches default, too!
+        n_observations = intensity * _area(hull)
+        n_replications = size
+    else:
+        raise ValueError(
+            f"Intensity and size not understood. Provide size as a tuple"
+            " containing (number of observations, number of replications)"
+            " with no specified intensity, or an intensity and size equal"
+            " to the number of replications."
+            " Recieved: `intensity={intensity}, size={size}`"
+        )
+    result = numpy.empty((n_replications, n_observations, 2))
+
+    bbox = _bbox(hull)
+
+    for i_replication in range(n_replications):
+        generating = True
+        i_observation = 0
+        while i_observation < n_observations:
+            x, y = (
+                numpy.random.random(bbox[0], bbox[2]),
+                numpy.random.random(bbox[1], bbox[3]),
+            )
+            if _within(x, y, hull):
+                result[i_observation, i_replication] = (x, y)
+            i_observation += 1
+    return result
+
+
+def simulate_from(coordinates, hull=None, size=None):
+    """
+    Simulate a pattern from the coordinates provided using a given assumption
+    about the hull of the process. 
+
+    Note: will always assume the implicit intensity of the process. 
+    """
+    n_observations = vertices.shape[0]
+    hull = _prepare_hull(coordinates, hull)
+    return simulate(hull, intensity=None, size=(n_observations, size))
+
+
+### Ripley's functions
+
+
+def f_function(
+    coordinates, support=None, distances=None, metric="euclidean", hull=None
+):
+    if isinstance(coordinates, TREE_TYPES):
+        tree = coordinates
+        coordinates = tree.data
+    coordinates, support, distances, metric, hull, _ = _prepare(
+        coordinates, support, distances, metric, hull, None
+    )
+    if distances is not None:
+        if distances.shape[0] == distances.shape[1] == coordinates.shape[0]:
+            warnings.Warn(
+                "The full distance matrix is not required for this function,"
+                " only the distance to the nearest neighbor within the pattern."
+                " Computing this, assuming provided distance matrix has rows"
+                " pertaining to the coordinates and columns pertaining to the"
+                " empty space sample points."
+            )
+            distances = distances.min(axis=1)
+        elif distance.shape[0] != coordinates.shape[0]:
+            raise ValueError(
+                "Distances are not aligned with coordinates! Distance"
+                " matrix must be (n_coordinates, p_random_points), but recieved"
+                " {distance.shape}"
+            )
+    else:
+        # if we only have a few, do 1000 empties.
+        # Otherwise, grow empties logarythmically
+        n_empty_points = numpy.minimum(
+            numpy.log10(coordinates.shape[0]).astype(int), 1000
+        )
+        intensity = n_empty_points / _area(hull)
+        randoms = simulate(hull, intensity=intensity)
+        try:
+            distances, _ = tree.query(randoms, k=1)
+        except NameError:
+            if metric != "euclidean":
+                raise ValueError(
+                    "KDTree can only use euclidean distances."
+                    " If you would like to use alternative distance"
+                    " metrics, compute them using scipy.spatial.distance.cdist"
+                    " "
+                )
+            tree = build_best_tree(coordinates, metric)
+            distances, _ = tree.query(randoms, k=1)
+
+    counts, bins = numpy.histogram(distances, bins=support)
+    return bins, numpy.cumsum(counts) / counts.sum()
+
+
+def g_function(coordinates, support=None, distances=None, metric="euclidean"):
+    if isinstance(coordinates, (spatial.distance.KDTree, spatial.distance.cKDTree)):
+        tree = coordinates
+        coordinates = tree.data
+    coordinates, support, distances, metric = _prepare(
+        coordinates, support, distances, metric, None, None
+    )
+    if distances is not None:
+        if distances.shape[0] == distances.shape[1] == coordinates.shape[0]:
+            warnings.Warn(
+                "The full distance matrix is not required for this function,"
+                " only the distance to the nearest neighbor within the pattern."
+                " Computing this and discarding the rest."
+            )
+            distances = distances.min(axis=1)
+        elif distance.shape[0] != coordinates.shape[0]:
+            raise ValueError(
+                "Distances are not aligned with coordinates! Distance"
+                " matrix must be (n_coordinates, n_coordinates), but recieved"
+                " {distance.shape}"
+            )
+    else:
+        try:
+            distances, indices = tree.query(coordinates, k=2)
+        except NameError:
+            tree = build_best_tree(coordinates, metric)
+            distances, indices = tree.query(coordinates, k=2)
+        finally:
+            # in case the tree returns self-neighbors in slot 2
+            # when there are coincident points
+            arange = numpy.arange(distances.shape[0])
+            distances = distances[arange, indices[:, 1] != arange]
+
+    counts, bins = numpy.histogram(distances, bins=support)
+    return bins, numpy.cumsum(counts) / counts.sum()
+
+
+def j_function(
+    coordinates, support=None, distances=None, metric="euclidean", hull=None
+):
+    gsupport, gstats = g_function(
+        coordinates, support=support, distances=distances, metric=metric
+    )
+    fsupport, fstats = f_function(
+        coordinates, support=support, distances=distances, metric=metric, hull=hull
+    )
+    if not numpy.allclose(gsupport, fsupport):
+        ffunction = interpolate.interp1d(fsupport, fstats)
+        fstats = ffunction(gsupport)
+    return gsupport, (1 - gstats) / (1 - fstats)
+
+
+def k_function(
+    coordinates,
+    support=None,
+    distances=None,
+    metric="euclidean",
+    hull=None,
+    edge_correction=None,
+):
+    coordinates, support, distances, metric, hull, edge_correction = _prepare(
+        coordinates, support, distances, metric, hull, edge_correction
+    )
+    n = coordinates.shape[0]
+    upper_tri_n = n * (n - 1) * 0.5
+    if distances is not None:
+        if distances.ndim == 1:
+            if distances.shape[0] != upper_tri_n:
+                raise ValueError(
+                    f"Shape of inputted distances is not square, nor is the upper triangular"
+                    " matrix matching the number of input points. The shape of the input matrix"
+                    " is {distance.shape}, but required shape is ({upper_tri_n},) or ({n},{n})"
+                )
+            upper_tri_distances = distances
+        elif distances.shape[0] == distances.shape[1] == n:
+            upper_tri_distances = distances[numpy.triu_indices_from(distances, k=1)]
+        else:
+            raise ValueError(
+                f"Shape of inputted distances is not square, nor is the upper triangular"
+                " matrix matching the number of input points. The shape of the input matrix"
+                " is {distance.shape}, but required shape is ({upper_tri_n},) or ({n},{n})"
+            )
+    n_pairs_less_than_d = (upper_tri_distances < support.reshape(-1, 1)).sum(axis=1)
+    intensity = n / _area(hull)
+    k_estimate = n_pairs_less_than_d * 2 / intensity
+    return support, kestimate
+
+
+def l_function(
+    coordinates,
+    support=None,
+    permutations=9999,
+    distances=None,
+    metric="euclidean",
+    hull=None,
+    edge_correction=None,
+):
+    # This is not equivalent to the estimator in pointpats, but that
+    # is likely flawed according to https://github.com/pysal/pointpats/issues/44
+    support, kestimate = k_function(
+        coordinates,
+        support=support,
+        distances=distances,
+        metric=metric,
+        hull=hull,
+        edge_correction=edge_correction,
+    )
+    return support, numpy.sqrt(kestimate / numpy.pi)
+
+
+### Ripley tests
+
+FtestResult = namedtuple(
+    "FtestResult", ("support", "statistic", "pvalue", "reference_distribution")
+)
+GtestResult = namedtuple(
+    "GtestResult", ("support", "statistic", "pvalue", "reference_distribution")
+)
+JtestResult = namedtuple(
+    "JtestResult", ("support", "statistic", "pvalue", "reference_distribution")
+)
+KtestResult = namedtuple(
+    "KtestResult", ("support", "statistic", "pvalue", "reference_distribution")
+)
+LtestResult = namedtuple(
+    "LtestResult", ("support", "statistic", "pvalue", "reference_distribution")
+)
+
+_ripley_dispatch = {
+    "F": (f_function, FtestResult),
+    "G": (g_function, GtestResult),
+    "J": (j_function, JtestResult),
+    "K": (k_function, KtestResult),
+    "L": (l_function, LtestResult),
+}
+
+
+def _ripley_test(
+    calltype,
+    coordinates,
+    support=None,
+    distances=None,
+    metric="euclidean",
+    hull=None,
+    edge_correction=None,
+    keep_replications=False,
+    n_replications=9999,
+):
+    stat_function, result_container = dispatch.get(calltype)
+    core_kwargs = dict(
+        support=None,
+        distances=None,
+        metric="euclidean",
+        hull=None,
+        edge_correction=None,
+    )
+    tree = build_best_tree(coordinates, metric=metric)  # amortize this
+    hull = _prepare_hull(tree.data)  # and this over replications
+    core_kwargs["hull"] = hull
+
+    observed_support, observed_statistic = stat_function(tree, **core_kwargs)
+    core_kwargs["support"] = observed_support
+
+    if keep_replications:
+        replications = numpy.empty((len(observed_support), n_replications))
+    for i_replication in range(n_replications):
+        replications_i = stat_function(tree, **core_kwargs)[1]
+        if keep_replications:
+            replications[i] = replications_i
+    return result_container(
+        observed_support, statistic, pvalue, replications if keep_replications else None
+    )
+
+
+def f_test(
+    coordinates,
+    support=None,
+    distances=None,
+    metric="euclidean",
+    hull=None,
+    edge_correction=None,
+    keep_replications=False,
+    n_replications=9999,
+):
+
+    return _ripley_test(
+        "F",
+        coordinates,
+        support=None,
+        distances=None,
+        metric="euclidean",
+        hull=None,
+        edge_correction=None,
+        keep_replications=False,
+        n_replications=9999,
+    )
+
+
+def g_test(
+    coordinates,
+    support=None,
+    distances=None,
+    metric="euclidean",
+    hull=None,
+    edge_correction=None,
+    keep_replications=False,
+    n_replications=9999,
+):
+    return _ripley_test(
+        "G",
+        coordinates,
+        support=None,
+        distances=None,
+        metric="euclidean",
+        hull=None,
+        edge_correction=None,
+        keep_replications=False,
+        n_replications=9999,
+    )
+
+
+def j_test(
+    coordinates,
+    support=None,
+    distances=None,
+    metric="euclidean",
+    hull=None,
+    edge_correction=None,
+    keep_replications=False,
+    n_replications=9999,
+):
+    return _ripley_test(
+        "J",
+        coordinates,
+        support=None,
+        distances=None,
+        metric="euclidean",
+        hull=None,
+        edge_correction=None,
+        keep_replications=False,
+        n_replications=9999,
+    )
+
+
+def k_test(
+    coordinates,
+    support=None,
+    distances=None,
+    metric="euclidean",
+    hull=None,
+    edge_correction=None,
+    n_replications=9999,
+):
+    return _ripley_test(
+        "K",
+        coordinates,
+        support=None,
+        distances=None,
+        metric="euclidean",
+        hull=None,
+        edge_correction=None,
+        keep_replications=False,
+        n_replications=9999,
+    )
+
+
+def l_test(
+    coordinates,
+    support=None,
+    distances=None,
+    metric="euclidean",
+    hull=None,
+    edge_correction=None,
+    n_replications=9999,
+):
+    return _ripley_test(
+        "L",
+        coordinates,
+        support=None,
+        distances=None,
+        metric="euclidean",
+        hull=None,
+        edge_correction=None,
+        keep_replications=False,
+        n_replications=9999,
+    )

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -4,7 +4,8 @@ from scipy import spatial, interpolate
 from typing import Union, Any
 from functools import singledispatch
 from collections import namedtuple
-from libpysal.cg import alpha_shape_auto, Arc_KDTree
+from libpysal.cg import alpha_shape_auto
+from libpysal.cg.kdtree import Arc_KDTree
 
 ### Utilities and dispatching
 

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -52,7 +52,7 @@ def _bbox(shape):
 def _(shape: numpy.ndarray):
     """
     If a shape is an array of points, compute the minima/maxima 
-    or let it slide if it's 1 dimensional & length 4
+    or let it pass through if it's 1 dimensional & length 4
     """
     if (shape.ndim == 1) & (len(shape) == 4):
         return shape
@@ -71,15 +71,17 @@ def _(shape: spatial.ConvexHull):
 @singledispatch
 def _contains(shape, x, y):
     """
-    Try to use the shape's contains method directly on XY 
+    Try to use the shape's contains method directly on XY.
+    Does not currently work on anything. 
     """
-    shape.contains((x, y))
+    return shape.contains((x, y))
 
 
 @_contains.register
 def _(shape: numpy.ndarray, x: float, y: float):
     """
     If provided an ndarray, assume it's a bbox
+    and return whether the point falls inside
     """
     xmin, xmax = shape[0], shape[2]
     ymin, ymax = shape[1], shape[3]
@@ -103,7 +105,8 @@ def _(shape: spatial.Delaunay, x: float, y: float):
 @_contains.register
 def _(shape: spatial.ConvexHull, x: float, y: float):
     """
-    For convex hulls, convert them first. 
+    For convex hulls, convert their exterior first into a Delaunay triangulation
+    and then use the delaunay dispatcher.
     """
     exterior = shape.points[shape.vertices]
     delaunay = spatial.Delaunay(exterior)
@@ -114,16 +117,18 @@ try:
     import shapely
 
     HAS_SHAPELY = True
-except ModuleNotFoundError:
-    HAS_SHAPELY = False
 
     @_contains.register
     def _(shape: shapely.geometry.Polygon, x: float, y: float):
         """
         If we know we're working with a shapely polygon, 
-        then use the contains method on the input shape. 
+        then use the contains method & cast input coords to a shapely point
         """
         return shape.contains(shapely.geometry.Point((x, y)))
+
+
+except ModuleNotFoundError:
+    HAS_SHAPELY = False
 
 
 try:
@@ -143,7 +148,7 @@ try:
     def _(shape: pygeos.Geometry, x: float, y: float):
         """
         If we know we're working with a pygeos polygon, 
-        then use pygeos.within
+        then use pygeos.within casting the points to a pygeos object too
         """
         return pygeos.within(pygeos.points((x, y)), shape)
 
@@ -161,6 +166,13 @@ except ModuleNotFoundError:
 
 
 def _build_best_tree(coordinates, metric):
+    """
+    Build the best query tree that can support the application.
+    Chooses from:
+    1. sklearn.KDTree if available and metric is simple
+    2. sklearn.BallTree if available and metric is complicated
+    3. scipy.spatial.cKDTree if nothing else
+    """
     tree = spatial.cKDTree
     try:
         from sklearn.neighbors import KDTree, BallTree
@@ -184,7 +196,7 @@ def _prepare_hull(coordinates, hull):
     """
     Construct a hull from the coordinates given a hull type
     Will either return:
-        - a bounding box of [xmin, ymin, xmax, ymax]
+        - a bounding box array of [xmin, ymin, xmax, ymax]
         - a scipy.spatial.ConvexHull object from the Qhull library
         - a shapely shape using alpha_shape_auto
     """
@@ -214,7 +226,24 @@ def _prepare_hull(coordinates, hull):
 
 
 def _prepare(coordinates, support, distances, metric, hull, edge_correction):
-
+    """
+    prepare the arguments to convert into a standard format
+    1. cast the coordinates to a numpy array
+    2. precomputed metrics must have distances provided
+    3. metrics must be callable or string
+    4. warn if distances are specified and metric is not default
+    5. make distances a numpy.ndarray
+    6. construct the support, accepting:
+        - num_steps -> a linspace with len(support) == num_steps
+                       from zero to a quarter of the bounding box's smallest side
+        - (stop, ) -> a linspace with len(support) == 20
+                 from zero to stop
+        - (start, stop) -> a linspace with len(support) == 20
+                           from start to stop
+        - (start, stop, num_steps) -> a linspace with len(support) == num_steps
+                                      from start to stop
+        - numpy.ndarray -> passed through
+    """
     # Throw early if edge correction is requested
     if edge_correction is not None:
         raise NotImplementedError("Edge correction is not currently implemented.")
@@ -229,23 +258,17 @@ def _prepare(coordinates, support, distances, metric, hull, edge_correction):
             "If metric =`precomputed` then distances must"
             " be provided as a (n,n) numpy array."
         )
-    elif not (isinstance(metric, str) or callable(metric)):
+    if not (isinstance(metric, str) or callable(metric)):
         raise TypeError(
             f"`metric` argument must be callable or a string. Recieved: {metric}"
         )
-    elif distances is not None and metric != "euclidean":
+    if distances is not None and metric != "euclidean":
         warnings.Warn(
             "Distances were provided. The specified metric will be ignored."
             " To use precomputed distances with a custom distance metric,"
             " do not specify a `metric` argument."
         )
-    elif isinstance(distances, numpy.ndarray):
-        assert (
-            distances.shape[0] == distances.shape[1] == coordinates.shape[0]
-        ), "Distances are not (n,n), aligned with coordinate matrix"
-
-    n = int(coordinates.shape[0])
-    upper_tri_n = int(n * (n - 1) * 0.5)
+        metric = "euclidean"
 
     if support is None:
         support = 20
@@ -280,6 +303,20 @@ def _prepare(coordinates, support, distances, metric, hull, edge_correction):
 
 
 def simulate(hull, intensity=None, size=None):
+    """
+    Simulate from the given hull with a specified intensity or size.
+    
+    Hulls can be:
+    - bounding boxes (numpy.ndarray with dim==1 and len == 4)
+    - scipy.spatial.ConvexHull
+    - shapely.geometry.Polygon
+    - pygeos.Geometry
+
+    If intensity is specified, size must be an integer reflecting
+    the number of realizations. 
+    If the size is specified as a tuple, then the intensity is 
+    determined by the area of the hull. 
+    """
     if size is None:
         if intensity is not None:
             # if intensity is provided, assume
@@ -359,30 +396,43 @@ def simulate_from(coordinates, hull=None, size=None):
 
 
 def f_function(
-    coordinates, support=None, distances=None, metric="euclidean", hull=None
+    coordinates,
+    support=None,
+    distances=None,
+    metric="euclidean",
+    hull=None,
+    edge_correction=None,
 ):
     if isinstance(coordinates, TREE_TYPES):
         tree = coordinates
         coordinates = tree.data
     coordinates, support, distances, metric, hull, _ = _prepare(
-        coordinates, support, distances, metric, hull, None
+        coordinates, support, distances, metric, hull, edge_correction
     )
     if distances is not None:
-        if distances.shape[0] == distances.shape[1] == coordinates.shape[0]:
-            warnings.Warn(
-                "The full distance matrix is not required for this function,"
-                " only the distance to the nearest neighbor within the pattern."
-                " Computing this, assuming provided distance matrix has rows"
-                " pertaining to the coordinates and columns pertaining to the"
-                " empty space sample points."
-            )
-            distances = distances.min(axis=1)
-        elif distance.shape[0] != coordinates.shape[0]:
-            raise ValueError(
-                "Distances are not aligned with coordinates! Distance"
-                " matrix must be (n_coordinates, p_random_points), but recieved"
-                " {distance.shape}"
-            )
+        n_observations = coordinates.shape[0]
+        if distances.ndim == 2:
+            k, p = distances.shape
+            if k == p == n:
+                warnings.Warn(
+                    f"A full distance matrix is not required for this function, and"
+                    f" the intput matrix is a square {n},{n} matrix. Only the"
+                    f" distances from p random points to their nearest neighbor within"
+                    f" the pattern is required, as an {n},p matrix. Assuming the"
+                    f" provided distance matrix has rows pertaining to input"
+                    f" pattern and columns pertaining to the output points."
+                )
+                distances = distances.min(axis=0)
+            elif k == n:
+                distances = distances.min(axis=0)
+            else:
+                raise ValueError(
+                    f"Distance matrix should have the same rows as the input"
+                    f" coordinates with p columns, where n may be equal to p."
+                    f" Recieved an {k},{p} distance matrix for {n} coordinates"
+                )
+        elif distances.ndim == 1:
+            p = len(distances)
     else:
         # if we only have a few, do 1000 empties.
         # Otherwise, grow empties slowly
@@ -395,16 +445,10 @@ def f_function(
 
         randoms = simulate(hull=hull, size=(n_empty_points, 1))
         try:
-            distances, _ = tree.query(randoms, k=1)
+            tree
         except NameError:
-            if metric != "euclidean":
-                raise ValueError(
-                    "KDTree can only use euclidean distances."
-                    " If you would like to use alternative distance"
-                    " metrics, compute them using scipy.spatial.distance.cdist"
-                    " "
-                )
             tree = _build_best_tree(coordinates, metric)
+        finally:
             distances, _ = tree.query(randoms, k=1)
 
     counts, bins = numpy.histogram(distances, bins=support)
@@ -413,32 +457,57 @@ def f_function(
     return bins, numpy.asarray([*fracs, 1])
 
 
-def g_function(coordinates, support=None, distances=None, metric="euclidean"):
+def g_function(
+    coordinates, support=None, distances=None, metric="euclidean", edge_correction=None,
+):
     if isinstance(coordinates, (spatial.KDTree, spatial.cKDTree)):
         tree = coordinates
         coordinates = tree.data
     coordinates, support, distances, metric, *_ = _prepare(
-        coordinates, support, distances, metric, None, None
+        coordinates, support, distances, metric, None, edge_correction
     )
     if distances is not None:
-        if distances.shape[0] == distances.shape[1] == coordinates.shape[0]:
-            warnings.Warn(
-                "The full distance matrix is not required for this function,"
-                " only the distance to the nearest neighbor within the pattern."
-                " Computing this and discarding the rest."
-            )
-            distances = distances.min(axis=1)
-        elif distance.shape[0] != coordinates.shape[0]:
+        if distances.ndim == 2:
+            if distances.shape[0] == distances.shape[1] == coordinates.shape[0]:
+                warnings.Warn(
+                    "The full distance matrix is not required for this function,"
+                    " only the distance to the nearest neighbor within the pattern."
+                    " Computing this and discarding the rest."
+                )
+                distances = distances.min(axis=1)
+            else:
+                k, p = distances.shape
+                n = coordinates.shape[0]
+                raise ValueError(
+                    " Input distance matrix has an invalid shape: {k},{p}."
+                    " Distances supplied can either be 2 dimensional"
+                    " square matrices with the same number of rows"
+                    " as `coordinates` ({n}) or 1 dimensional and contain"
+                    " the shortest distance from each point in "
+                    " `coordinates` to some other point in coordinates."
+                )
+        elif distances.ndim == 1:
+            if distance.shape[0] != coordinates.shape[0]:
+                raise ValueError(
+                    f"Distances are not aligned with coordinates! Distance"
+                    f" matrix must be (n_coordinates, n_coordinates), but recieved"
+                    f" {distance.shape} instead of ({coordinates.shape[0]},)"
+                )
+        else:
             raise ValueError(
-                "Distances are not aligned with coordinates! Distance"
-                " matrix must be (n_coordinates, n_coordinates), but recieved"
-                " {distance.shape}"
+                "Distances supplied can either be 2 dimensional"
+                " square matrices with the same number of rows"
+                " as `coordinates` or 1 dimensional and contain"
+                " the shortest distance from each point in "
+                " `coordinates` to some other point in coordinates."
+                " Input matrix was {distances.ndim} dimensioanl"
             )
     else:
         try:
-            distances, indices = tree.query(coordinates, k=2)
+            tree
         except NameError:
             tree = _build_best_tree(coordinates, metric)
+        finally:
             distances, indices = tree.query(coordinates, k=2)
 
     counts, bins = numpy.histogram(distances, bins=support)
@@ -448,13 +517,27 @@ def g_function(coordinates, support=None, distances=None, metric="euclidean"):
 
 
 def j_function(
-    coordinates, support=None, distances=None, metric="euclidean", hull=None
+    coordinates,
+    support=None,
+    distances=None,
+    metric="euclidean",
+    hull=None,
+    edge_correction=None,
 ):
     gsupport, gstats = g_function(
-        coordinates, support=support, distances=distances, metric=metric
+        coordinates,
+        support=support,
+        distances=distances,
+        metric=metric,
+        edge_correction=edge_correction,
     )
     fsupport, fstats = f_function(
-        coordinates, support=support, distances=distances, metric=metric, hull=hull
+        coordinates,
+        support=support,
+        distances=distances,
+        metric=metric,
+        hull=hull,
+        edge_correction=edge_correction,
     )
     if not numpy.allclose(gsupport, fsupport):
         ffunction = interpolate.interp1d(fsupport, fstats)
@@ -462,7 +545,9 @@ def j_function(
     both_zero = (gstats == 1) & (fstats == 1)
     with numpy.errstate(invalid="ignore", divide="ignore"):
         hazard_ratio = (1 - gstats) / (1 - fstats)
+
     hazard_ratio[both_zero] = 1
+
     return gsupport, hazard_ratio
 
 
@@ -512,9 +597,10 @@ def l_function(
     metric="euclidean",
     hull=None,
     edge_correction=None,
+    linearized=False,
 ):
-    # This is not equivalent to the estimator in pointpats, but that
-    # is likely flawed according to https://github.com/pysal/pointpats/issues/44
+    # linearization proposed by Besag (1977)
+
     support, k_estimate = k_function(
         coordinates,
         support=support,
@@ -523,7 +609,8 @@ def l_function(
         hull=hull,
         edge_correction=edge_correction,
     )
-    return support, numpy.sqrt(k_estimate / numpy.pi)
+
+    return support, numpy.sqrt(k_estimate / numpy.pi) - linearized * support
 
 
 ### Ripley tests
@@ -563,6 +650,7 @@ def _ripley_test(
     edge_correction=None,
     keep_replications=False,
     n_replications=9999,
+    **kwargs,
 ):
     stat_function, result_container = dispatch.get(calltype)
     core_kwargs = dict(
@@ -696,6 +784,7 @@ def l_test(
     metric="euclidean",
     hull=None,
     edge_correction=None,
+    linearized=False,
     n_replications=9999,
 ):
     return _ripley_test(
@@ -707,5 +796,6 @@ def l_test(
         hull=None,
         edge_correction=None,
         keep_replications=False,
+        linearized=False,
         n_replications=9999,
     )

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -434,11 +434,6 @@ def g_function(coordinates, support=None, distances=None, metric="euclidean"):
         except NameError:
             tree = _build_best_tree(coordinates, metric)
             distances, indices = tree.query(coordinates, k=2)
-        finally:
-            # in case the tree returns self-neighbors in slot 2
-            # when there are coincident points
-            arange = numpy.arange(distances.shape[0])
-            distances = distances[arange, indices[:, 1] != arange]
 
     counts, bins = numpy.histogram(distances, bins=support)
     fracs = numpy.cumsum(counts) / counts.sum()

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -403,6 +403,23 @@ def f_function(
     hull=None,
     edge_correction=None,
 ):
+    """
+    coordinates : numpy.ndarray, (n,2)
+        input coordinates to function
+    support : tuple of length 1, 2, or 3, int, or numpy.ndarray
+        tuple, encoding (stop,), (start, stop), or (start, stop, num)
+        int, encoding number of equally-spaced intervals
+        numpy.ndarray, used directly within numpy.histogram
+    distances: numpy.ndarray, (n, p) or (p,)
+        distances from every point in a random point set of size p
+        to some point in `coordinates`
+    metric: str or callable
+        distance metric to use when building search tree
+    hull: bounding box, scipy.spatial.ConvexHull, shapely.geometry.Polygon, or pygeos.Geometry
+        the hull used to construct a random sample pattern, if distances is None
+    edge_correction: bool or str
+        whether or not to conduct edge correction. Not yet implemented.
+    """
     if isinstance(coordinates, TREE_TYPES):
         tree = coordinates
         coordinates = tree.data
@@ -460,6 +477,22 @@ def f_function(
 def g_function(
     coordinates, support=None, distances=None, metric="euclidean", edge_correction=None,
 ):
+    """
+    coordinates : numpy.ndarray, (n,2)
+        input coordinates to function
+    support : tuple of length 1, 2, or 3, int, or numpy.ndarray
+        tuple, encoding (stop,), (start, stop), or (start, stop, num)
+        int, encoding number of equally-spaced intervals
+        numpy.ndarray, used directly within numpy.histogram
+    distances: numpy.ndarray, (n, p) or (p,)
+        distances from every point in a random point set of size p
+        to some point in `coordinates`
+    metric: str or callable
+        distance metric to use when building search tree
+    edge_correction: bool or str
+        whether or not to conduct edge correction. Not yet implemented.
+    """
+
     if isinstance(coordinates, (spatial.KDTree, spatial.cKDTree)):
         tree = coordinates
         coordinates = tree.data
@@ -524,17 +557,40 @@ def j_function(
     hull=None,
     edge_correction=None,
 ):
+    """
+    coordinates : numpy.ndarray, (n,2)
+        input coordinates to function
+    support : tuple of length 1, 2, or 3, int, or numpy.ndarray
+        tuple, encoding (stop,), (start, stop), or (start, stop, num)
+        int, encoding number of equally-spaced intervals
+        numpy.ndarray, used directly within numpy.histogram
+    distances: tuple of numpy.ndarray
+        precomputed distances to use to evaluate the j function. 
+        The first must be of shape (n,n) or (n,) and is used in the g function.
+        the second must be of shape (n,p) or (p,) (with p possibly equal to n)
+        used in the f function.
+    metric: str or callable
+        distance metric to use when building search tree
+    hull: bounding box, scipy.spatial.ConvexHull, shapely.geometry.Polygon, or pygeos.Geometry
+        the hull used to construct a random sample pattern for the f function.
+    edge_correction: bool or str
+        whether or not to conduct edge correction. Not yet implemented.
+    """
+    if distances is not None:
+        g_distances, f_distances = distances
+    else:
+        g_distances = f_distances = None
     gsupport, gstats = g_function(
         coordinates,
         support=support,
-        distances=distances,
+        distances=g_distances,
         metric=metric,
         edge_correction=edge_correction,
     )
     fsupport, fstats = f_function(
         coordinates,
         support=support,
-        distances=distances,
+        distances=f_distances,
         metric=metric,
         hull=hull,
         edge_correction=edge_correction,
@@ -559,6 +615,23 @@ def k_function(
     hull=None,
     edge_correction=None,
 ):
+    """
+    coordinates : numpy.ndarray, (n,2)
+        input coordinates to function
+    support : tuple of length 1, 2, or 3, int, or numpy.ndarray
+        tuple, encoding (stop,), (start, stop), or (start, stop, num)
+        int, encoding number of equally-spaced intervals
+        numpy.ndarray, used directly within numpy.histogram
+    distances: numpy.ndarray, (n, p) or (p,)
+        distances from every point in a random point set of size p
+        to some point in `coordinates`
+    metric: str or callable
+        distance metric to use when building search tree
+    hull: bounding box, scipy.spatial.ConvexHull, shapely.geometry.Polygon, or pygeos.Geometry
+        the hull used to construct a random sample pattern, if distances is None
+    edge_correction: bool or str
+        whether or not to conduct edge correction. Not yet implemented.
+    """
     coordinates, support, distances, metric, hull, edge_correction = _prepare(
         coordinates, support, distances, metric, hull, edge_correction
     )
@@ -599,7 +672,27 @@ def l_function(
     edge_correction=None,
     linearized=False,
 ):
-    # linearization proposed by Besag (1977)
+    """
+    coordinates : numpy.ndarray, (n,2)
+        input coordinates to function
+    support : tuple of length 1, 2, or 3, int, or numpy.ndarray
+        tuple, encoding (stop,), (start, stop), or (start, stop, num)
+        int, encoding number of equally-spaced intervals
+        numpy.ndarray, used directly within numpy.histogram
+    distances: numpy.ndarray, (n, p) or (p,)
+        distances from every point in a random point set of size p
+        to some point in `coordinates`
+    metric: str or callable
+        distance metric to use when building search tree
+    hull: bounding box, scipy.spatial.ConvexHull, shapely.geometry.Polygon, or pygeos.Geometry
+        the hull used to construct a random sample pattern, if distances is None
+    edge_correction: bool or str
+        whether or not to conduct edge correction. Not yet implemented.
+    linearized : bool
+        whether or not to subtract the expected value from l at each 
+        distance bin. This centers the l function on zero for all distances.
+        Proposed by Besag (1977) #TODO: fix besag ref
+    """
 
     support, k_estimate = k_function(
         coordinates,
@@ -695,17 +788,40 @@ def f_test(
     keep_replications=False,
     n_replications=9999,
 ):
+    """
+    coordinates : numpy.ndarray, (n,2)
+        input coordinates to function
+    support : tuple of length 1, 2, or 3, int, or numpy.ndarray
+        tuple, encoding (stop,), (start, stop), or (start, stop, num)
+        int, encoding number of equally-spaced intervals
+        numpy.ndarray, used directly within numpy.histogram
+    distances: numpy.ndarray, (n, p) or (p,)
+        distances from every point in a random point set of size p
+        to some point in `coordinates`
+    metric: str or callable
+        distance metric to use when building search tree
+    hull: bounding box, scipy.spatial.ConvexHull, shapely.geometry.Polygon, or pygeos.Geometry
+        the hull used to construct a random sample pattern, if distances is None
+    edge_correction: bool or str
+        whether or not to conduct edge correction. Not yet implemented.
+    keep_replications: bool
+        whether or not to keep the simulation envelopes. If so, 
+        will be returned as the result's reference_distribution attribute
+    n_replications: int
+        how many simulations to conduct, assuming that the reference pattern
+        has complete spatial randomness. 
+    """
 
     return _ripley_test(
         "F",
         coordinates,
-        support=None,
-        distances=None,
-        metric="euclidean",
-        hull=None,
-        edge_correction=None,
-        keep_replications=False,
-        n_replications=9999,
+        support=support,
+        distances=distances,
+        metric=metric,
+        hull=hull,
+        edge_correction=edge_correction,
+        keep_replications=keep_replications,
+        n_replications=n_replications,
     )
 
 
@@ -719,16 +835,39 @@ def g_test(
     keep_replications=False,
     n_replications=9999,
 ):
+    """
+    coordinates : numpy.ndarray, (n,2)
+        input coordinates to function
+    support : tuple of length 1, 2, or 3, int, or numpy.ndarray
+        tuple, encoding (stop,), (start, stop), or (start, stop, num)
+        int, encoding number of equally-spaced intervals
+        numpy.ndarray, used directly within numpy.histogram
+    distances: numpy.ndarray, (n, p) or (p,)
+        distances from every point in a random point set of size p
+        to some point in `coordinates`
+    metric: str or callable
+        distance metric to use when building search tree
+    hull: bounding box, scipy.spatial.ConvexHull, shapely.geometry.Polygon, or pygeos.Geometry
+        the hull used to construct a random sample pattern, if distances is None
+    edge_correction: bool or str
+        whether or not to conduct edge correction. Not yet implemented.
+    keep_replications: bool
+        whether or not to keep the simulation envelopes. If so, 
+        will be returned as the result's reference_distribution attribute
+    n_replications: int
+        how many simulations to conduct, assuming that the reference pattern
+        has complete spatial randomness. 
+    """
     return _ripley_test(
         "G",
         coordinates,
-        support=None,
-        distances=None,
-        metric="euclidean",
-        hull=None,
-        edge_correction=None,
-        keep_replications=False,
-        n_replications=9999,
+        support=support,
+        distances=distances,
+        metric=metric,
+        hull=hull,
+        edge_correction=edge_correction,
+        keep_replications=keep_replications,
+        n_replications=n_replications,
     )
 
 
@@ -742,16 +881,39 @@ def j_test(
     keep_replications=False,
     n_replications=9999,
 ):
+    """
+    coordinates : numpy.ndarray, (n,2)
+        input coordinates to function
+    support : tuple of length 1, 2, or 3, int, or numpy.ndarray
+        tuple, encoding (stop,), (start, stop), or (start, stop, num)
+        int, encoding number of equally-spaced intervals
+        numpy.ndarray, used directly within numpy.histogram
+    distances: numpy.ndarray, (n, p) or (p,)
+        distances from every point in a random point set of size p
+        to some point in `coordinates`
+    metric: str or callable
+        distance metric to use when building search tree
+    hull: bounding box, scipy.spatial.ConvexHull, shapely.geometry.Polygon, or pygeos.Geometry
+        the hull used to construct a random sample pattern, if distances is None
+    edge_correction: bool or str
+        whether or not to conduct edge correction. Not yet implemented.
+    keep_replications: bool
+        whether or not to keep the simulation envelopes. If so, 
+        will be returned as the result's reference_distribution attribute
+    n_replications: int
+        how many simulations to conduct, assuming that the reference pattern
+        has complete spatial randomness. 
+    """
     return _ripley_test(
         "J",
         coordinates,
-        support=None,
-        distances=None,
-        metric="euclidean",
-        hull=None,
-        edge_correction=None,
-        keep_replications=False,
-        n_replications=9999,
+        support=support,
+        distances=distances,
+        metric=metric,
+        hull=hull,
+        edge_correction=edge_correction,
+        keep_replications=keep_replications,
+        n_replications=n_replications,
     )
 
 
@@ -764,16 +926,39 @@ def k_test(
     edge_correction=None,
     n_replications=9999,
 ):
+    """
+    coordinates : numpy.ndarray, (n,2)
+        input coordinates to function
+    support : tuple of length 1, 2, or 3, int, or numpy.ndarray
+        tuple, encoding (stop,), (start, stop), or (start, stop, num)
+        int, encoding number of equally-spaced intervals
+        numpy.ndarray, used directly within numpy.histogram
+    distances: numpy.ndarray, (n, p) or (p,)
+        distances from every point in a random point set of size p
+        to some point in `coordinates`
+    metric: str or callable
+        distance metric to use when building search tree
+    hull: bounding box, scipy.spatial.ConvexHull, shapely.geometry.Polygon, or pygeos.Geometry
+        the hull used to construct a random sample pattern, if distances is None
+    edge_correction: bool or str
+        whether or not to conduct edge correction. Not yet implemented.
+    keep_replications: bool
+        whether or not to keep the simulation envelopes. If so, 
+        will be returned as the result's reference_distribution attribute
+    n_replications: int
+        how many simulations to conduct, assuming that the reference pattern
+        has complete spatial randomness. 
+    """
     return _ripley_test(
         "K",
         coordinates,
-        support=None,
-        distances=None,
-        metric="euclidean",
-        hull=None,
-        edge_correction=None,
-        keep_replications=False,
-        n_replications=9999,
+        support=support,
+        distances=distances,
+        metric=metric,
+        hull=hull,
+        edge_correction=edge_correction,
+        keep_replications=keep_replications,
+        n_replications=n_replications,
     )
 
 
@@ -787,15 +972,37 @@ def l_test(
     linearized=False,
     n_replications=9999,
 ):
+    """
+    coordinates : numpy.ndarray, (n,2)
+        input coordinates to function
+    support : tuple of length 1, 2, or 3, int, or numpy.ndarray
+        tuple, encoding (stop,), (start, stop), or (start, stop, num)
+        int, encoding number of equally-spaced intervals
+        numpy.ndarray, used directly within numpy.histogram
+    distances: numpy.ndarray, (n, p) or (p,)
+        distances from every point in a random point set of size p
+        to some point in `coordinates`
+    metric: str or callable
+        distance metric to use when building search tree
+    hull: bounding box, scipy.spatial.ConvexHull, shapely.geometry.Polygon, or pygeos.Geometry
+        the hull used to construct a random sample pattern, if distances is None
+    edge_correction: bool or str
+        whether or not to conduct edge correction. Not yet implemented.
+    keep_replications: bool
+        whether or not to keep the simulation envelopes. If so, 
+        will be returned as the result's reference_distribution attribute
+    n_replications: int
+        how many simulations to conduct, assuming that the reference pattern
+        has complete spatial randomness. 
+    """
     return _ripley_test(
         "L",
         coordinates,
-        support=None,
-        distances=None,
-        metric="euclidean",
-        hull=None,
-        edge_correction=None,
-        keep_replications=False,
-        linearized=False,
-        n_replications=9999,
+        support=support,
+        distances=distances,
+        metric=metric,
+        hull=hull,
+        edge_correction=edge_correction,
+        keep_replications=keep_replications,
+        n_replications=n_replications,
     )

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -51,8 +51,11 @@ def _bbox(shape):
 @_bbox.register
 def _(shape: numpy.ndarray):
     """
-    If a shape is an array of points, compute the minima/maxima
+    If a shape is an array of points, compute the minima/maxima 
+    or let it slide if it's 1 dimensional & length 4
     """
+    if (shape.ndim == 1) & (len(shape) == 4):
+        return shape
     return numpy.array([*shape.min(axis=0), *shape.max(axis=0)])
 
 

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -159,7 +159,7 @@ except ModuleNotFoundError:
 
 
 def _build_best_tree(coordinates, metric):
-    tree = scipy.spatial.cKDTree
+    tree = spatial.cKDTree
     try:
         from sklearn.neighbors import KDTree, BallTree
 
@@ -336,9 +336,9 @@ def simulate(hull, intensity=None, size=None):
                 numpy.random.uniform(bbox[1], bbox[3]),
             )
             if _contains(hull, x, y):
-                result[i_observation, i_replication] = (x, y)
+                result[i_replication, i_observation] = (x, y)
             i_observation += 1
-    return result
+    return result.squeeze()
 
 
 def simulate_from(coordinates, hull=None, size=None):
@@ -402,11 +402,13 @@ def f_function(
             distances, _ = tree.query(randoms, k=1)
 
     counts, bins = numpy.histogram(distances, bins=support)
-    return bins, numpy.cumsum(counts) / counts.sum()
+    fracs = numpy.cumsum(counts) / counts.sum()
+
+    return bins, numpy.asarray([*fracs, 1])
 
 
 def g_function(coordinates, support=None, distances=None, metric="euclidean"):
-    if isinstance(coordinates, (spatial.distance.KDTree, spatial.distance.cKDTree)):
+    if isinstance(coordinates, (spatial.KDTree, spatial.cKDTree)):
         tree = coordinates
         coordinates = tree.data
     coordinates, support, distances, metric = _prepare(
@@ -439,7 +441,9 @@ def g_function(coordinates, support=None, distances=None, metric="euclidean"):
             distances = distances[arange, indices[:, 1] != arange]
 
     counts, bins = numpy.histogram(distances, bins=support)
-    return bins, numpy.cumsum(counts) / counts.sum()
+    fracs = numpy.cumsum(counts) / counts.sum()
+
+    return bins, numpy.asarray([*fracs, 1])
 
 
 def j_function(

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -198,7 +198,7 @@ def _prepare(coordinates, support, distances, metric, hull, edge_correction):
 
     # cast to coordinate array
     coordinates = numpy.asarray(coordinates)
-    hull = _prepare_hull(hull)
+    hull = _prepare_hull(coordinates, hull)
 
     # evaluate distances
     if (distances is None) and metric == "precomputed":
@@ -527,7 +527,7 @@ def _ripley_test(
         support=None, metric="euclidean", hull=None, edge_correction=None,
     )
     tree = _build_best_tree(coordinates, metric=metric)  # amortize this
-    hull = _prepare_hull(tree.data)  # and this over replications
+    hull = _prepare_hull(tree.data, hull)  # and this over replications
     core_kwargs["hull"] = hull
 
     if calltype in ("F", "J"):

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -491,7 +491,7 @@ def k_function(
     n_pairs_less_than_d = (upper_tri_distances < support.reshape(-1, 1)).sum(axis=1)
     intensity = n / _area(hull)
     k_estimate = ((n_pairs_less_than_d * 2) / n) / intensity
-    return support, kestimate
+    return support, k_estimate
 
 
 def l_function(
@@ -505,7 +505,7 @@ def l_function(
 ):
     # This is not equivalent to the estimator in pointpats, but that
     # is likely flawed according to https://github.com/pysal/pointpats/issues/44
-    support, kestimate = k_function(
+    support, k_estimate = k_function(
         coordinates,
         support=support,
         distances=distances,
@@ -513,7 +513,7 @@ def l_function(
         hull=hull,
         edge_correction=edge_correction,
     )
-    return support, numpy.sqrt(kestimate / numpy.pi)
+    return support, numpy.sqrt(k_estimate / numpy.pi)
 
 
 ### Ripley tests

--- a/esda/ripley.py
+++ b/esda/ripley.py
@@ -277,10 +277,10 @@ def simulate(hull, intensity=None, size=None):
         else:
             raise ValueError(
                 f"Intensity and size not understood. Provide size as a tuple"
-                " containing (number of observations, number of replications)"
-                " with no specified intensity, or an intensity and size equal"
-                " to the number of replications."
-                " Recieved: `intensity={intensity}, size={size}`"
+                f" containing (number of observations, number of replications)"
+                f" with no specified intensity, or an intensity and size equal"
+                f" to the number of replications."
+                f" Recieved: `intensity={intensity}, size={size}`"
             )
 
     elif intensity is not None and isinstance(size, int):  # catches default, too!
@@ -289,10 +289,10 @@ def simulate(hull, intensity=None, size=None):
     else:
         raise ValueError(
             f"Intensity and size not understood. Provide size as a tuple"
-            " containing (number of observations, number of replications)"
-            " with no specified intensity, or an intensity and size equal"
-            " to the number of replications."
-            " Recieved: `intensity={intensity}, size={size}`"
+            f" containing (number of observations, number of replications)"
+            f" with no specified intensity, or an intensity and size equal"
+            f" to the number of replications."
+            f" Recieved: `intensity={intensity}, size={size}`"
         )
     result = numpy.empty((n_replications, n_observations, 2))
 
@@ -447,8 +447,8 @@ def k_function(
             if distances.shape[0] != upper_tri_n:
                 raise ValueError(
                     f"Shape of inputted distances is not square, nor is the upper triangular"
-                    " matrix matching the number of input points. The shape of the input matrix"
-                    " is {distance.shape}, but required shape is ({upper_tri_n},) or ({n},{n})"
+                    f" matrix matching the number of input points. The shape of the input matrix"
+                    f" is {distance.shape}, but required shape is ({upper_tri_n},) or ({n},{n})"
                 )
             upper_tri_distances = distances
         elif distances.shape[0] == distances.shape[1] == n:
@@ -456,8 +456,8 @@ def k_function(
         else:
             raise ValueError(
                 f"Shape of inputted distances is not square, nor is the upper triangular"
-                " matrix matching the number of input points. The shape of the input matrix"
-                " is {distance.shape}, but required shape is ({upper_tri_n},) or ({n},{n})"
+                f" matrix matching the number of input points. The shape of the input matrix"
+                f" is {distance.shape}, but required shape is ({upper_tri_n},) or ({n},{n})"
             )
     n_pairs_less_than_d = (upper_tri_distances < support.reshape(-1, 1)).sum(axis=1)
     intensity = n / _area(hull)


### PR DESCRIPTION
This is done to facilitate discussion about a simpler `scipy.stats`-style API for Ripley functions. If this is felt more reasonable in `pointpats`, that's totally cool. Hopefully we might incorporate this style of logic into other areas of esda, amiing at `scipy.stats` as the style of implementation.

My main exploration with this is to satisfy 4 principles:

0. Be as performant as possible. This means *use numpy and scipy as often as possible. avoid list comprehensions and for loops.* I think this is achieved since there is only one for loop/comprehension in the module.
1. Keep time-to-estimation short. This means *custom classes and secondary/tertiary instantions of classes should be minimized*. I think this is satisfied because all estimators take a numpy array and return numpy arrays or result namedtuples. 
2. Make a user of `scipy.stats` feel immediately at home. This means *return values should be `namedtuples` with standard names for their properties*, such as `statistic` and `pvalue`, regardless of the statistical result. I think this is satisfied, since the APIs, naming, and structure are very similar.
3. Use keywords, not classes for power features. This means *opening up sklearn-style distance and metric specifications that allow users to specify their own nulls*. I think this is satisfied, since power users can simulate their own processes, compute any fancy distance metric they want, and send them along to the statistics using the `distance` keyword. It also means all of these can accept *network* distances, and support `spaghetti`. 
 
I will document this further & fill out with testing in the coming days. I aim to have a fully documented & working example by next PySAL development call (1 May 2020). 