### PR TITLE
Adbscan fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you are having issues, please talk to us in the [gitter room](https://gitter.
 License
 -------
 
-The project is licensed under the [BSD license](https://github.com/pysal/esda/blob/master/LICENSE).
+The project is licensed under the [BSD 3-Clause license](https://github.com/pysal/esda/blob/master/LICENSE).
 
 Funding
 -------

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ The project is licensed under the [BSD license](https://github.com/pysal/esda/bl
 Funding
 -------
 
-<img src="figs/nsf_logo.jpg" width="50"> Award #1421935 [New Approaches to Spatial Distribution Dynamics](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1421935)
+[<img align="middle" src="figs/nsf_logo.jpg" width="100">](https://www.nsf.gov/index.jsp) National Science Foundation Award #1421935: [New Approaches to Spatial Distribution Dynamics](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1421935)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-Exploratory Spatial Data Analysis in PySAL
-==========================================
+# Exploratory Spatial Data Analysis in PySAL
 
 [![Build Status](https://travis-ci.org/pysal/esda.svg?branch=master)](https://travis-ci.org/pysal/esda)
 [![DOI](https://zenodo.org/badge/81873636.svg)](https://zenodo.org/badge/latestdoi/81873636)
 
 Methods for  testing for global and local autocorrelation in areal unit data.
 
-Installation
-------------
+
+## Installation
 
 Install esda by running:
 
@@ -15,28 +14,29 @@ Install esda by running:
 $ pip install esda
 ```
 
-#### Requirements
+
+## Requirements
 
 - libpysal
 
-Contribute
-----------
+
+## Contribute
 
 PySAL-esda is under active development and contributors are welcome.
 
 If you have any suggestion, feature request, or bug report, please open a new [issue](https://github.com/pysal/esda/issues) on GitHub. To submit patches, please follow the PySAL development [guidelines](https://github.com/pysal/pysal/wiki) and open a [pull request](https://github.com/pysal/esda). Once your changes get merged, you’ll automatically be added to the [Contributors List](https://github.com/pysal/esda/graphs/contributors).
 
-Support
--------
+
+## Support
 
 If you are having issues, please talk to us in the [gitter room](https://gitter.im/pysal/pysal).
  
-License
--------
+ 
+## License
 
 The project is licensed under the [BSD 3-Clause license](https://github.com/pysal/esda/blob/master/LICENSE).
 
-Funding
--------
+
+## Funding
 
 [<img align="middle" src="figs/nsf_logo.jpg" width="100">](https://www.nsf.gov/index.jsp) National Science Foundation Award #1421935: [New Approaches to Spatial Distribution Dynamics](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1421935)

--- a/esda/adbscan.py
+++ b/esda/adbscan.py
@@ -184,7 +184,7 @@ class ADBSCAN(_ClusterMixin, _BaseEstimator):
             columns=["rep-%s" % str(i).zfill(zfiller) for i in range(self.reps)],
         )
         # Multi-core implementation of parallel draws
-        if (self.n_jobs is -1) or (self.n_jobs > 1):
+        if (self.n_jobs == -1) or (self.n_jobs > 1):
             pool = _setup_pool(self.n_jobs)
             # Set different parallel seeds!!!
             warn_msg = (
@@ -329,7 +329,7 @@ def remap_lbls(solus, xys, xy=["X", "Y"], n_jobs=1):
             index=solus.index,
             columns=solus.columns,
         )
-        if (n_jobs is -1) or (n_jobs > 1):
+        if (n_jobs == -1) or (n_jobs > 1):
             pool = _setup_pool(n_jobs)
             s_ids = solus.drop(ref, axis=1).columns.tolist()
             to_loop_over = [(solus[s], ref_centroids, ref_kdt, xys, xy) for s in s_ids]

--- a/esda/adbscan.py
+++ b/esda/adbscan.py
@@ -420,7 +420,9 @@ def ensemble(solus_relabelled):
     counts = np.array(list(map(f, solus_relabelled.values)))
     winner = counts[:, 0]
     votes = counts[:, 1].astype(int) / solus_relabelled.shape[1]
-    pred = pandas.DataFrame({"lbls": winner, "pct": votes}, index=solus_relabelled.index)
+    pred = pandas.DataFrame(
+        {"lbls": winner, "pct": votes}, index=solus_relabelled.index
+    )
     return pred
 
 
@@ -503,8 +505,10 @@ def get_cluster_boundary(labels, xys, xy=["X", "Y"], n_jobs=1, crs=None, step=1)
     try:
         from geopandas import GeoSeries
     except ModuleNotFoundError:
-        raise ModuleNotFoundError('geopandas is required in order '
-                                  ' to get cluster boundaries')
+
+        def GeoSeries(data, index=None, crs=None):
+            return list(data)
+
     lbl_type = type(labels.iloc[0])
     noise = lbl_type(-1)
     ids_in_cluster = labels[labels != noise].index

--- a/esda/adbscan.py
+++ b/esda/adbscan.py
@@ -12,11 +12,12 @@ from scipy.spatial import cKDTree
 from collections import Counter
 from sklearn.cluster import DBSCAN
 from sklearn.neighbors import KNeighborsClassifier
+from sklearn.base import BaseEstimator as _BaseEstimator, ClusterMixin as _ClusterMixin
 
 __all__ = ["ADBSCAN", "remap_lbls", "ensemble", "get_cluster_boundary"]
 
 
-class ADBSCAN:
+class ADBSCAN(_ClusterMixin, _BaseEstimator):
     """
     A-DBSCAN, as introduced in :cite:`ab_gl_vm2020joue`.
 

--- a/esda/adbscan.py
+++ b/esda/adbscan.py
@@ -7,7 +7,6 @@ __author__ = "Dani Arribas-Bel <daniel.arribas.bel@gmail.com>"
 import warnings
 import pandas
 import numpy as np
-from geopandas import GeoSeries
 from libpysal.cg.alpha_shapes import alpha_shape_auto
 from scipy.spatial import cKDTree
 from collections import Counter
@@ -500,7 +499,11 @@ def get_cluster_boundary(labels, xys, xy=["X", "Y"], n_jobs=1, crs=None, step=1)
     >>> polys[0].wkt
     'POLYGON ((0.7217553174317995 0.8192869956700687, 0.7605307121989587 0.9086488808086682, 0.9177741225129434 0.8568503024577332, 0.8126209616521135 0.6262871483113925, 0.6125260668293881 0.5475861559192435, 0.5425443680112613 0.7546476915298572, 0.7217553174317995 0.8192869956700687))'
     """
-
+    try:
+        from geopandas import GeoSeries
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError('geopandas is required in order '
+                                  ' to get cluster boundaries')
     lbl_type = type(labels.iloc[0])
     noise = lbl_type(-1)
     ids_in_cluster = labels[labels != noise].index

--- a/esda/geary.py
+++ b/esda/geary.py
@@ -102,12 +102,12 @@ class Geary(object):
         if not isinstance(w, weights.W):
             raise TypeError('w must be a pysal weights object, got {}'
                             ' instead'.format(type(w)))
-        self.al = w.to_adjlist()
         y = np.asarray(y).flatten()
         self.n = len(y)
         self.y = y
         w.transform = transformation
         self.w = w
+        self.al = w.to_adjlist()
         self.permutations = permutations
         self.__moments()
         xn = range(len(y))
@@ -176,7 +176,7 @@ class Geary(object):
         self.seC_norm = vc_norm ** (0.5)
 
     def __calc(self, y):
-        al = self.al
+        
         num = (al.weight * ((y[al.focal]-y[al.neighbor])**2) ).sum()
         a = (self.n - 1) * num 
         return a / self.den

--- a/esda/geary.py
+++ b/esda/geary.py
@@ -107,7 +107,8 @@ class Geary(object):
         self.y = y
         w.transform = transformation
         self.w = w
-        self.al = w.to_adjlist()
+        self._focal_ix, self._neighbor_ix = w.sparse.nonzero()
+        self._weights = w.sparse.data
         self.permutations = permutations
         self.__moments()
         xn = range(len(y))
@@ -175,9 +176,11 @@ class Geary(object):
         self.seC_rand = vc_rand ** (0.5)
         self.seC_norm = vc_norm ** (0.5)
 
+    
     def __calc(self, y):
-        
-        num = (al.weight * ((y[al.focal]-y[al.neighbor])**2) ).sum()
+        num = (self._weights * 
+               ((y[self._focal_ix] 
+                 - y[self._neighbor_ix])**2) ).sum()
         a = (self.n - 1) * num 
         return a / self.den
 

--- a/tests/test_geary.py
+++ b/tests/test_geary.py
@@ -4,6 +4,8 @@ import unittest
 from libpysal.io import open as popen
 from libpysal import examples
 from libpysal.common import pandas
+from libpysal.weights import W
+from libpysal.weights import Rook
 
 from esda import geary
 import numpy as np
@@ -13,47 +15,44 @@ PANDAS_EXTINCT = pandas is None
 class Geary_Tester(unittest.TestCase):
     """Geary class for unit tests."""
     def setUp(self):
-        self.w = popen(examples.get_path("book.gal")).read()
-        f = popen(examples.get_path("book.txt"))
-        self.y = np.array(f.by_col['y'])
+        w = Rook.from_shapefile(examples.get_path("columbus.shp"))
+        f = popen(examples.get_path("columbus.dbf"))
+        w.transform = 'r'
+        self.w = w
+        self.y = np.array(f.by_col['CRIME'])
 
     def test_Geary(self):
         c = geary.Geary(self.y, self.w, permutations=0)
-        self.assertAlmostEqual(c.C, 0.33301083591331254)
+        self.assertAlmostEqual(c.C, 0.5154408058652411)
         self.assertAlmostEqual(c.EC, 1.0)
+        self.assertAlmostEqual(c.VC_norm, 0.011403109626468939)
+        self.assertAlmostEqual(c.seC_norm,0.10678534368755357 )
+        self.assertAlmostEqual(c.p_norm, 2.8436375936967054e-06)
+        self.assertAlmostEqual(c.z_norm,-4.5376938201608)
 
-        self.assertAlmostEqual(c.VC_norm, 0.031805300245097874)
-        self.assertAlmostEqual(c.p_norm, 9.2018240680169505e-05)
-        self.assertAlmostEqual(c.z_norm, -3.7399778367629564)
-        self.assertAlmostEqual(c.seC_norm, 0.17834040553138225)
-
-        self.assertAlmostEquals(c.VC_rand,0.033411917666958356)
-        self.assertAlmostEquals(c.p_rand,0.00013165646189214729)
-        self.assertAlmostEquals(c.z_rand, -3.6489513837253944)
-        self.assertAlmostEquals(c.seC_rand, 0.18278927120309429)
+        self.assertAlmostEquals(c.VC_rand,0.010848882767131886)
+        self.assertAlmostEquals(c.p_rand,1.6424069196305004e-06)
+        self.assertAlmostEquals(c.z_rand, -4.652156651668989)
 
         np.random.seed(12345)
         c = geary.Geary(self.y, self.w, permutations=999)
-        self.assertAlmostEquals(c.C, 0.33301083591331254)
-        self.assertAlmostEquals(c.EC, 1.0)
+        self.assertAlmostEqual(c.C, 0.5154408058652411)
+        self.assertAlmostEqual(c.EC, 1.0)
+        self.assertAlmostEqual(c.VC_norm, 0.011403109626468939)
+        self.assertAlmostEqual(c.seC_norm,0.10678534368755357 )
+        self.assertAlmostEqual(c.p_norm, 2.8436375936967054e-06)
+        self.assertAlmostEqual(c.z_norm,-4.5376938201608)
 
-        self.assertAlmostEquals(c.VC_norm, 0.031805300245097874)
-        self.assertAlmostEquals(c.p_norm, 9.2018240680169505e-05)
-        self.assertAlmostEquals(c.z_norm, -3.7399778367629564)
-        self.assertAlmostEquals(c.seC_norm, 0.17834040553138225)
-
-        self.assertAlmostEquals(c.VC_rand,0.033411917666958356)
-        self.assertAlmostEquals(c.p_rand,0.00013165646189214729)
-        self.assertAlmostEquals(c.z_rand, -3.6489513837253944)
-        self.assertAlmostEquals(c.seC_rand, 0.18278927120309429)
+        self.assertAlmostEquals(c.VC_rand,0.010848882767131886)
+        self.assertAlmostEquals(c.p_rand,1.6424069196305004e-06)
+        self.assertAlmostEquals(c.z_rand, -4.652156651668989)
 
 
-        self.assertAlmostEquals(c.EC_sim, 0.9980676303238214)
-        self.assertAlmostEquals(c.VC_sim, 0.034430408799858946)
+
+        self.assertAlmostEquals(c.EC_sim,0.9981883958193233)
+        self.assertAlmostEquals(c.VC_sim,  0.010631247074115058)
         self.assertAlmostEquals(c.p_sim, 0.001)
-        self.assertAlmostEquals(c.p_z_sim, 0.00016908100514811952)
-        self.assertAlmostEquals(c.z_sim, -3.5841621159171746)
-        self.assertAlmostEquals(c.seC_sim, 0.18555432843202269)
+        self.assertAlmostEquals(c.p_z_sim, 1.4207015378575605e-06)
 
     @unittest.skipIf(PANDAS_EXTINCT, 'missing pandas')
     def test_by_col(self):


### PR DESCRIPTION
This makes 
1. geopandas a function-level import 
2.  `adbscan` (formally) a scikit-learn estimator by making its inheritance from `_ClusterMixin` and `BaseEstimator` explicit. 

I don't think this affects anything, but it'd be good to check more than the existing test suite...