### PR TITLE
(BUG) missing comma in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def setup_package():
     _groups_files = {
         'base': 'requirements.txt',
         'tests': 'requirements_tests.txt',
-        'docs': 'requirements_docs.txt'
+        'docs': 'requirements_docs.txt',
         'plus': 'requirements_plus.txt'
     }
 


### PR DESCRIPTION
Add [the missing comma in setup.py](https://github.com/pysal/esda/blob/master/setup.py#L46). 

[It is causing an error in the installation of the github version](https://github.com/weikang9009/giddy/runs/859877500).