### PR TITLE
fix concatenation for random statistics

### DIFF
--- a/esda/crand.py
+++ b/esda/crand.py
@@ -464,7 +464,7 @@ def parallel_crand(
         )
     larger, rlocals = zip(*worker_out)
     larger = np.hstack(larger).flatten()
-    rlocals = np.hstack(rlocals).flatten()
+    rlocals = np.row_stack(rlocals)
     return larger, rlocals
 
 


### PR DESCRIPTION
There were two issues in the concatenation code for the local statistics
for the parallel conditional permutation code. The original code is
below:

> rlocals = numpy.hstack(rlocals).flatten()

The first big issue is that rlocals is a numpy array containing the
random realizations of simulations for observations within each
processing job. This code, however, will flatten that out into an array
of chunk_size*p_permutations, which certainly is not correct.

The second (slightly smaller) issue is that hstack fails when its chunks
are heterogeneously sized, even when you just want to stack over the
rows. For example:

```
>>> a = numpy.arange(20).reshape(4,5)
>>> b = numpy.arange(10).reshape(2,5)
>>> c = numpy.hstack((a,b)) # Fails!
```

That last numpy.hstack line fails with a ValueError, since "all of the
input array dimensions for the concatenation axis must match exactly."
That means that a and b have to have the same number of rows to be
hstacked. But, since they're 2-dimensional, one can *row_stack* them
just fine:

```
>>> c = numpy.row_stack((a,b)) # Success!
```
c contains the first 4 rows from a, and then the last 2 rows are b. 

```
array([[ 0,  1,  2,  3,  4],
       [ 5,  6,  7,  8,  9],
       [10, 11, 12, 13, 14],
       [15, 16, 17, 18, 19],
       [ 0,  1,  2,  3,  4],
       [ 5,  6,  7,  8,  9]])

```

This is what we need to do in the rlocals case, since each chunk might be
slightly different in size, but still will always be (chunk_size,
p_permutations).