### PR TITLE
Moments for Moran's I_i following Sokal 1998

### DIFF
--- a/docsrc/_static/references.bib
+++ b/docsrc/_static/references.bib
@@ -197,3 +197,12 @@ url="https://doi.org/10.1023/A:1008929526011"
   year={2019},
   publisher={SAGE Publications Sage UK: London, England}
 }
+
+@article{sokal1998local,
+	title={Local spatial autocorrelation in a biological model},
+	author={Sokal, Robert R and Oden, Neal L, and Thomson, Barbara A},
+	journal={Geographical Analysis},
+	year={1998},
+	volume=30,
+	issue=4
+}

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -932,14 +932,12 @@ class Moran_Local(object):
                    analytical expectation of Is under conditional permutation, 
                    from :cite:`sokal1998local`. Varies strongly by site, since it
                    conditions on z_i. We recommend using EI_sim, not EIc, 
-                   for analysis. This EIc is only provided for reproducibility, 
-                   but may be close to EI_sim in well-behaved datasets. 
+                   for analysis. This EIc is only provided for reproducibility.
     VIc          : array
                    analytical variance of Is under conditional permutation,
                    from :cite:`sokal1998local`. Varies strongly by site, since 
                    it conditions on z_i. We recommend using VI_sim, not VIc,
-                   for analysis. This VIc is only provided for reproducibility,
-                   but may be close to VI_sim in well-behaved datasets. 
+                   for analysis. This VIc is only provided for reproducibility.
     seI_sim      : array
                    (if permutations>0)
                    standard deviations of Is under permutations.

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -14,7 +14,7 @@ from .crand import (
     _prepare_univariate,
     _prepare_bivariate,
 )
-from warnings import warn
+from warnings import warn, simplefilter
 import scipy.stats as stats
 import numpy as np
 import tempfile
@@ -1061,7 +1061,7 @@ class Moran_Local(object):
     def __moments(self):
         W = self.w.sparse
         z = self.z
-        warnings.simplefilter('always', sparse.SparseEfficiencyWarning)
+        simplefilter('always', sparse.SparseEfficiencyWarning)
         n = self.n
         m2 = (z*z).sum()/n
         wi = numpy.asarray(W.sum(axis=1)).flatten()

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -1087,16 +1087,16 @@ class Moran_Local(object):
         b2 = m4/m2**2
             
         expectation = -wi / (n-1)
-        variance_sokal = (wi2*(n - b2)/(n-1)
+        # assume that "avoiding identical subscripts" in :cite:`Anselin1995` 
+        # includes i==h and i==k, we can use the form due to :cite:`Sokal1998` below. 
+        # wikh = _wikh_fast(W)
+        # variance_anselin = (wi2 * (n - b2)/(n-1)
+        #        + 2*wikh*(2*b2 - n) / ((n-1)*(n-2))
+        #                    - wi**2/(n-1)**2)
+        self.EI = expectation
+        self.VI = (wi2*(n - b2)/(n-1)
                           + (wi**2 - wi2)*(2*b2 - n)/((n-1)*(n-2))
                           - (-wi / (n-1))**2)
-        wikh = _wikh_fast(W)
-        variance_anselin = (wi2 * (n - b2)/(n-1)
-                + 2*wikh*(2*b2 - n) / ((n-1)*(n-2))
-                            - wi**2/(n-1)**2)
-        self.EI = expectation
-        self.VI_sokal = variance_sokal
-        self.VI_anselin = variance_anselin
 
     @property
     def _statistic(self):

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -917,6 +917,29 @@ class Moran_Local(object):
     VI_sim       : array
                    (if permutations>0)
                    variance of Is from permutations
+    EI           : array
+                   analytical expectation of Is under total permutation, 
+                   from :cite:`Anselin1995`. Is the same at each site, 
+                   and equal to the expectation of I itself when 
+                   transformation='r'. We recommend using EI_sim, not EI,
+                   for analysis. This EI is only provided for reproducibility.
+    VI           : array
+                   analytical variance of Is under total permutation, 
+                   from :cite:`Anselin1995`. Varies according only to 
+                   cardinality. We recommend using VI_sim, not VI, for
+                   analysis. This VI is only provided for reproducibility.
+    EIc          : array
+                   analytical expectation of Is under conditional permutation, 
+                   from :cite:`sokal1998local`. Varies strongly by site, since it
+                   conditions on z_i. We recommend using EI_sim, not EIc, 
+                   for analysis. This EIc is only provided for reproducibility, 
+                   but may be close to EI_sim in well-behaved datasets. 
+    VIc          : array
+                   analytical variance of Is under conditional permutation,
+                   from :cite:`sokal1998local`. Varies strongly by site, since 
+                   it conditions on z_i. We recommend using VI_sim, not VIc,
+                   for analysis. This VIc is only provided for reproducibility,
+                   but may be close to VI_sim in well-behaved datasets. 
     seI_sim      : array
                    (if permutations>0)
                    standard deviations of Is under permutations.
@@ -1088,7 +1111,7 @@ class Moran_Local(object):
             
         expectation = -wi / (n-1)
         # assume that "avoiding identical subscripts" in :cite:`Anselin1995` 
-        # includes i==h and i==k, we can use the form due to :cite:`Sokal1998` below. 
+        # includes i==h and i==k, we can use the form due to :cite:`sokal1998local` below. 
         # wikh = _wikh_fast(W)
         # variance_anselin = (wi2 * (n - b2)/(n-1)
         #        + 2*wikh*(2*b2 - n) / ((n-1)*(n-2))
@@ -1673,7 +1696,7 @@ def _wikh_fast(W, sokal_correction=False):
 
     w_{i(kh)} = \sum_{k \neq i}^n \sum_{h \neq i}^n w_ik * w_hk
 
-    If the :cite:`Sokal1998` version is used, then we also have h \neq k
+    If the :cite:`sokal1998local` version is used, then we also have h \neq k
     Since this version introduces a simplification in the expression
     where this function is called, the defaults should always return
     the version in the original :cite:`Anselin1995 paper`.  

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -1069,12 +1069,14 @@ class Moran_Local(object):
         wi2 = np.asarray(W.multiply(W).sum(axis=1)).flatten()
         # ---------------------------------------------------------
         # Conditional randomization null, Sokal 1998, Eqs. A7 & A8
+        # assume that division is as written, so that
+        # a - b / (n - 1) means a - (b / (n-1))
         # ---------------------------------------------------------
         expectation = -(z**2 * wi) / ((n-1)*m2)
         variance = ((z/m2)**2 * 
                     (n/(n-2)) * 
-                    ((wi2 - wi**2) / (n-1)) *
-                    (m2 - z**2) / (n-1))
+                    (wi2 - (wi**2 / (n-1))) *
+                    (m2 - (z**2 / (n-1))))
 
         self.EIc = expectation
         self.VIc = variance

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -1673,10 +1673,10 @@ def _wikh_fast(W, sokal_correction=False):
 
     w_{i(kh)} = \sum_{k \neq i}^n \sum_{h \neq i}^n w_ik * w_hk
 
-    if the sokal correction is used (default), then we also have h \neq k
-    Since the sokal correction introduces a simplification in the expression
-    where this is used, the defaults should always return the version in 
-    the original :cite:`Anselin1995 paper`.  
+    If the :cite:`Sokal1998` version is used, then we also have h \neq k
+    Since this version introduces a simplification in the expression
+    where this function is called, the defaults should always return
+    the version in the original :cite:`Anselin1995 paper`.  
 
     Arguments
     ---------

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -1731,7 +1731,7 @@ def _wikh_slow(W, sokal_correction=False):
     """
     W = W.toarray()
     (n,n) = W.shape
-    result = numpy.empty((n,))
+    result = np.empty((n,))
     # for each observation
     for i in range(n):
         acc = 0

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -218,7 +218,7 @@ class Moran(object):
         self.VI_norm = v_num / v_den - (1.0 / (n - 1)) ** 2
         self.seI_norm = self.VI_norm ** (1 / 2.0)
 
-        # variance under total randomization
+        # variance under randomization
         xd4 = z ** 4
         xd2 = z ** 2
         k_num = xd4.sum() / n

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -145,20 +145,32 @@ class Moran_Local_Tester(unittest.TestCase):
             seed=SEED,
         )
         
-        wikh_fast = moran._wikh_fast(lm.w)
-        wikh_slow = moran._wikh_slow(lm.w)
-        wikh_fast_c = moran._wikh_fast(lm.w, sokal_correction=True)
-        wikh_slow_c = moran._wikh_slow(lm.w, sokal_correction=True)
+        wikh_fast = moran._wikh_fast(lm.w.sparse)
+        wikh_slow = moran._wikh_slow(lm.w.sparse)
+        wikh_fast_c = moran._wikh_fast(lm.w.sparse, sokal_correction=True)
+        wikh_slow_c = moran._wikh_slow(lm.w.sparse, sokal_correction=True)
 
-        numpy.testing.assert_allclose(wikh_fast, wikh_slow)
-        numpy.testing.assert_allclose(wikh_fast, wikh_slow)
+        np.testing.assert_allclose(wikh_fast, wikh_slow, rtol=RTOL, atol=ATOL)
+        np.testing.assert_allclose(wikh_fast, wikh_slow, rtol=RTOL, atol=ATOL)
+        EIc = np.array([-0.00838113, -0.0243949 , -0.07031778, 
+                           -0.21520869, -0.16547163, -0.00178435, 
+                           -0.11531888, -0.36138555, -0.05471258, -0.09413562])
+        VIc = np.array([0.03636013, 0.10412408, 0.28600769, 
+                           0.26389674, 0.21576683, 0.00779261, 
+                           0.44633942, 0.57696508, 0.12929777, 0.3730742 ])
+        
+        EI = -np.ones((10,))/9
+        VI = np.array([0.47374172, 0.47356458, 0.47209663, 
+                       0.15866023, 0.15972526, 0.47376436, 
+                       0.46927721, 0.24584217, 0.26498308, 0.47077467])
 
-        assert NotImplementedError()
-        numpy.testing.assert_allclose(lm.EIc, ...)
-        numpy.testing.assert_allclose(lm.VIc, ...)
-        numpy.testing.assert_allclose(lm.EI, ...)
-        numpy.testing.assert_allclose(lm.VI_sokal, ...)
-        numpy.testing.assert_allclose(lm.VI_anselin, ...)
+        
+
+
+        np.testing.assert_allclose(lm.EIc, EIc, rtol=RTOL, atol=ATOL)
+        np.testing.assert_allclose(lm.VIc, VIc, rtol=RTOL, atol=ATOL)
+        np.testing.assert_allclose(lm.EI, EI, rtol=RTOL, atol=ATOL)
+        np.testing.assert_allclose(lm.VI, VI, rtol=RTOL, atol=ATOL)
 
 
 class Moran_Local_BV_Tester(unittest.TestCase):

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -136,6 +136,30 @@ class Moran_Local_Tester(unittest.TestCase):
         self.assertAlmostEqual(lm.z_z_sim[0], -0.6990291160835514)
         self.assertAlmostEqual(lm.z_p_z_sim[0], 0.24226691753791396)
 
+    def test_local_moments(self):
+        lm = moran.Moran_Local(
+            self.y,
+            self.w,
+            transformation="r",
+            permutations=0,
+            seed=SEED,
+        )
+        
+        wikh_fast = moran._wikh_fast(lm.w)
+        wikh_slow = moran._wikh_slow(lm.w)
+        wikh_fast_c = moran._wikh_fast(lm.w, sokal_correction=True)
+        wikh_slow_c = moran._wikh_slow(lm.w, sokal_correction=True)
+
+        numpy.testing.assert_allclose(wikh_fast, wikh_slow)
+        numpy.testing.assert_allclose(wikh_fast, wikh_slow)
+
+        assert NotImplementedError()
+        numpy.testing.assert_allclose(lm.EIc, ...)
+        numpy.testing.assert_allclose(lm.VIc, ...)
+        numpy.testing.assert_allclose(lm.EI, ...)
+        numpy.testing.assert_allclose(lm.VI_sokal, ...)
+        numpy.testing.assert_allclose(lm.VI_anselin, ...)
+
 
 class Moran_Local_BV_Tester(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
[Sokal (1998)](https://onlinelibrary.wiley.com/doi/pdf/10.1111/j.1538-4632.1998.tb00406.x) provides a pretty solid argument about the differences between analytical moments derived from the "total" randomization null and the "conditional" randomization null for local Moran's I. The original article by @lanselin uses the "total" null, as does [spdep](https://github.com/r-spatial/spdep/blob/master/R/localmoran.R#L61). 

This adds both the "total" and the "conditional" implementations to the `Moran_Local` class, in hopes of shedding a bit more light on the [Bivand and Wong (2018)](https://link.springer.com/article/10.1007/s11749-018-0599-x) results about heteroskedasticity and our conditional permutation method. I also have a numba-fied version of the `w_i(kh)` quantity from the original paper. 

Tests are in progress. 