### PR TITLE
[DOC] Updating read the docs api for local join counts, local geary

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,15 +27,18 @@ Gamma Statistic
 
     esda.Gamma
 
+
 .. _geary_api:
 
-Geary Statistic
+Geary Statistics
 ---------------
 
 .. autosummary::
    :toctree: generated/
 
     esda.Geary
+    esda.Geary_Local
+    esda.Geary_Local_MV
 
 
 .. _getis_api:
@@ -48,6 +51,7 @@ Getis-Ord Statistics
 
     esda.G
     esda.G_Local
+
 
 .. _join_api:
 
@@ -66,13 +70,7 @@ Join Count Local Statistics
    :toctree: generated/
 
     esda.Join_Counts_Local
-
-Join Count Multivariate Statistics
------------------------------------
-
-.. autosummary::
-   :toctree: generated/
-
+    esda.Join_Counts_Local_BV
     esda.Join_Counts_Local_MV
 
 


### PR DESCRIPTION
Updated `api.rst` to include all local join count functions and local geary functions (from GSOC 2020). 

Nested `Geary_Local` and `Geary_Local_MV` under Geary Statistics. Nested `Join_Counts_Local_BV` and `Join_Counts_Local_MV` under Join Count Local Statistics. 

In addition, reviewed docstrings for the GSOC2020 functions as I noticed mine are not fully rendering in rtd. Unclear why. For example: [moran.py](https://github.com/pysal/esda/blob/master/esda/moran.py), [moran on rtd](https://pysal.org/esda/generated/esda.Moran.html#esda.Moran); [losh.py](https://github.com/pysal/esda/blob/master/esda/losh.py), [LOSH on rtd](https://pysal.org/esda/generated/esda.LOSH.html#esda.LOSH). Thoughts?