### PR TITLE
add pygeos-tolerant fails for the module

### DIFF
--- a/esda/__init__.py
+++ b/esda/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 """
 :mod:`esda` --- Exploratory Spatial Data Analysis
 =================================================

--- a/esda/map_comparison.py
+++ b/esda/map_comparison.py
@@ -1,5 +1,10 @@
-import numpy, pygeos, pandas, geopandas
+import numpy, pandas
 from scipy.special import entr
+
+try:
+    import pygeos
+except:
+    pass  # gets handled in the _cast function.
 
 # from nowosad and stepinski
 # https://doi.org/10.1080/13658816.2018.1511794
@@ -21,6 +26,13 @@ def _cast(collection):
     """
     Cast a collection to a pygeos geometry array.
     """
+    try:
+        import pygeos, geopandas
+    except (ImportError, ModuleNotFoundError) as exception:
+        raise type(exception)(
+            "pygeos and geopandas are required for map comparison statistics."
+        )
+
     if isinstance(collection, (geopandas.GeoSeries, geopandas.GeoDataFrame)):
         return collection.geometry.values.data.squeeze()
     elif pygeos.is_geometry(collection).all():

--- a/esda/map_comparison.py
+++ b/esda/map_comparison.py
@@ -3,7 +3,7 @@ from scipy.special import entr
 
 try:
     import pygeos
-except:
+except (ImportError, ModuleNotFoundError):
     pass  # gets handled in the _cast function.
 
 # from nowosad and stepinski

--- a/esda/shape.py
+++ b/esda/shape.py
@@ -1,5 +1,11 @@
 import numpy
 import pandas
+
+try:
+    import pygeos
+except (ImportError, ModuleNotFoundError):
+    pass  # gets handled at the _cast level.
+
 from .crand import njit, prange
 
 

--- a/esda/shape.py
+++ b/esda/shape.py
@@ -1,13 +1,18 @@
-import pygeos
-import geopandas, pandas
 import numpy
-from numba import njit, prange
+import pandas
+from .crand import njit, prange
+
 
 # -------------------- UTILITIES --------------------#
 def _cast(collection):
     """
     Cast a collection to a pygeos geometry array.
     """
+    try:
+        import pygeos, geopandas
+    except (ImportError, ModuleNotFoundError) as exception:
+        raise type(exception)("pygeos and geopandas are required for shape statistics.")
+
     if isinstance(collection, (geopandas.GeoSeries, geopandas.GeoDataFrame)):
         return collection.geometry.values.data.squeeze()
     elif pygeos.is_geometry(collection).all():


### PR DESCRIPTION
This moves the pygeos imports into a safe spot in the `_cast` function (and depends on `crand` for the `numba` logic. 

Tests pass in a `pygeos`-less environment, but you can't use the map comparison or shape statistics measures. 

I think if we add more modules with `pygeos` functionality, we need to make it a dependency in the next 6-month cycle. 