### PR TITLE
add .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,16 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+source = esda
+disable_warnings=include-ignored
+
+[report]
+omit = 
+    docs/conf.py
+    setup.py
+    */tests/*
+    versioneer.py
+    *_version.py
+
+[html]
+directory = coverage_html_report


### PR DESCRIPTION
This PR adds a `.coveragerc` configuration to not check certain files for coverage.