### PR TITLE
Use more precise calculation of minimum bounding circle area

### DIFF
--- a/esda/shape.py
+++ b/esda/shape.py
@@ -181,8 +181,8 @@ def minimum_bounding_circle_ratio(collection):
     (1963)
     """
     ga = _cast(collection)
-    mbc = shapely.minimum_bounding_circle(ga)
-    return shapely.area(ga) / shapely.area(mbc)
+    mbca = (shapely.minimum_bounding_radius(ga) ** 2) * numpy.pi
+    return shapely.area(ga) / mbca
 
 
 def radii_ratio(collection):

--- a/esda/tests/test_shape.py
+++ b/esda/tests/test_shape.py
@@ -79,7 +79,7 @@ def test_nmi():
 
 def test_mbc():
     observed = esda.shape.minimum_bounding_circle_ratio(shape)
-    testing.assert_allclose(observed, 0.437571, atol=ATOL)
+    testing.assert_allclose(observed, 0.434765, atol=ATOL)
 
 
 def test_reflexive_angle_ratio():


### PR DESCRIPTION
We now compute an area of a minimum bounding circle from its polygonal representation, which is not as precise as it could be. I am replacing it with `shapely.minimum_bounding_radius` and classic pi times the radius squared formula to avoid that.

The actual numerical difference is negligible in any useful case but there's no reason to not be more precise. And it will likely be faster this way.