### PR TITLE
add `rtree` as optional dependency

### DIFF
--- a/ci/310-DEV.yaml
+++ b/ci/310-DEV.yaml
@@ -13,7 +13,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - rtree
   # optional
   - geopandas>=0.12.0
+  - rtree
   - shapely>=2

--- a/ci/310-numba-DEV.yaml
+++ b/ci/310-numba-DEV.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - rtree
   # optional
   - geopandas>=0.12.0
+  - rtree
   - shapely>=2

--- a/ci/310-numba.yaml
+++ b/ci/310-numba.yaml
@@ -17,4 +17,5 @@ dependencies:
   - pytest-xdist
   # optional
   - geopandas>=0.7.0
+  - rtree
   - shapely>=2

--- a/ci/310.yaml
+++ b/ci/310.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - rtree
   # optional
   - geopandas>=0.7.0
+  - rtree
   - shapely>=2

--- a/ci/311-DEV.yaml
+++ b/ci/311-DEV.yaml
@@ -11,6 +11,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
+  # optional
   - rtree
   # doc build
   - nbsphinx

--- a/ci/311-numba-DEV.yaml
+++ b/ci/311-numba-DEV.yaml
@@ -12,8 +12,8 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - rtree
   # optional
+  - rtree
   # doc build
   - nbsphinx
   - numpydoc

--- a/ci/311-numba.yaml
+++ b/ci/311-numba.yaml
@@ -15,9 +15,9 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - rtree
   # optional
   - geopandas>=0.7.0
+  - rtree
   - shapely>=2.0
   # doc build
   - nbsphinx

--- a/ci/311.yaml
+++ b/ci/311.yaml
@@ -14,9 +14,9 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - rtree
   # optional
   - geopandas>=0.7.0
+  - rtree
   - shapely>=2
   # doc build
   - nbsphinx

--- a/ci/38-minimal-numba.yaml
+++ b/ci/38-minimal-numba.yaml
@@ -15,7 +15,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - rtree
   # optional
   - geopandas>=0.12.0,<0.13
+  - rtree
   - shapely>=2

--- a/ci/38-minimal.yaml
+++ b/ci/38-minimal.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - rtree
   # optional
   - geopandas>=0.12.0,<0.13
+  - rtree
   - shapely>=2

--- a/ci/39-numba.yaml
+++ b/ci/39-numba.yaml
@@ -15,7 +15,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - rtree
   # optional
   - geopandas>=0.7.0
+  - rtree
   - shapely>=2

--- a/ci/39.yaml
+++ b/ci/39.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - rtree
   # optional
   - geopandas>=0.7.0
+  - rtree
   - shapely>=2

--- a/environment.yml
+++ b/environment.yml
@@ -9,5 +9,6 @@ dependencies:
   - matplotlib
   - numba
   - pandas
+  - rtree
   - scikit-learn
   - scipy>=0.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,10 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-"libpysal",
-"pandas>1.4",
-"scikit-learn>=1.0",
-"scipy>=1.9"
+    "libpysal",
+    "pandas>1.4",
+    "scikit-learn>=1.0",
+    "scipy>=1.9"
 ]
 
 
@@ -42,6 +42,9 @@ Home = "https://pysal.org/esda/"
 Repository = "https://github.com/pysal/esda"
 
 [project.optional-dependencies]
+topo = [
+    "rtree>=1.0",
+]
 tests = [
     "codecov",
     "coverage",


### PR DESCRIPTION
* This PR moves toward #304 by adding `rtree` as optional dependency (unless we want to have it as a hard dep).
* Example fix in [CI (ubuntu-latest, ci/310.yaml)](https://github.com/pysal/esda/pull/307#logs)
* ***Other failures unrelated to this PR.***