### PR TITLE
ENH: natively support Graph in losh and sihouettes modules

### DIFF
--- a/esda/silhouettes.py
+++ b/esda/silhouettes.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 from scipy import sparse as sp
 from scipy.sparse import csgraph as cg
+from libpysal import weights
 
 try:
     import pandas as pd
@@ -27,7 +28,7 @@ def _raise_initial_error():
         missing.append("pandas")
     raise ImportError(
         "This function requires scikit-learn and "
-        "pandas to be installed. Missing {','.join(missing)}."
+        f"pandas to be installed. Missing {','.join(missing)}."
     )
 
 
@@ -176,13 +177,13 @@ def path_silhouette(
                 else:
                     psils = subgraph_solutions
             if return_nbfc:
-                closest_connecting_label_[
-                    this_component_mask
-                ] = closest_connecting_label
+                closest_connecting_label_[this_component_mask] = (
+                    closest_connecting_label
+                )
             if return_nbfc_score:
-                closest_connection_score_[
-                    this_component_mask
-                ] = closest_connection_score
+                closest_connection_score_[this_component_mask] = (
+                    closest_connection_score
+                )
             psils_[this_component_mask] = psils
         closest_connection_score = closest_connection_score_
         closest_connecting_label = closest_connecting_label_
@@ -308,7 +309,15 @@ def boundary_silhouette(
     if not HAS_REQUIREMENTS:
         _raise_initial_error()
 
-    alist = W.to_adjlist(drop_islands=drop_islands)
+    if isinstance(W, weights.W):
+        alist = W.to_adjlist(drop_islands=drop_islands)
+        index = W.id_order
+    else:
+        if drop_islands:
+            alist = W.adjacency.drop(W.isolates).reset_index()
+        else:
+            alist = W.adjacancy.reset_index()
+        index = W.unique_ids
     labels = np.asarray(labels)
     if callable(metric):
         full_distances = metric(data)
@@ -330,7 +339,7 @@ def boundary_silhouette(
     assert 0 == (full_distances < 0).sum(), (
         "Distance metric has negative values, " "which is not supported"
     )
-    label_frame = pd.DataFrame(labels, index=W.id_order, columns=["label"])
+    label_frame = pd.DataFrame(labels, index=index, columns=["label"])
     alist = alist.merge(
         label_frame, left_on="focal", right_index=True, how="left"
     ).merge(

--- a/esda/silhouettes.py
+++ b/esda/silhouettes.py
@@ -63,7 +63,7 @@ def path_silhouette(
                 matrix of data with N observations and P covariates.
     labels  :   np.ndarray (N,)
                 flat vector of the L labels assigned over N observations.
-    W       :   pysal.W object
+    W       :   libpysal.weights.W | libpysal.graph.Graph
                 spatial weights object reflecting the spatial connectivity
                 in the problem under analysis
     D       :   np.ndarray (N,N)
@@ -266,7 +266,7 @@ def boundary_silhouette(
                 observation, and each clumn should be one feature.
     labels  :   (N_obs,) array of labels
                 the labels corresponding to the group each observation is assigned.
-    W       :   pysal.weights.W object
+    W       :   libpysal.weights.W | libpysal.graph.Graph
                 a spatial weights object containing the connectivity structure
                 for the data
     metric  :   callable, array,

--- a/esda/tests/test_losh.py
+++ b/esda/tests/test_losh.py
@@ -1,5 +1,5 @@
 # based off: https://github.com/pysal/esda/blob/master/tests/test_moran.py#L96
-import unittest
+import pytest
 
 import libpysal
 import numpy as np
@@ -7,25 +7,25 @@ import numpy as np
 from esda.losh import LOSH
 
 
-class Losh_Tester(unittest.TestCase):
-    def setUp(self):
+parametrize_w = pytest.mark.parametrize(
+    "w",
+    [
+        libpysal.io.open(libpysal.examples.get_path("stl.gal")).read(),
+        libpysal.graph.Graph.from_W(
+            libpysal.io.open(libpysal.examples.get_path("stl.gal")).read()
+        ),
+    ],
+    ids=["W", "Graph"],
+)
+
+class TestLosh:
+    def setup_method(self):
         np.random.seed(10)
-        self.w = libpysal.io.open(libpysal.examples.get_path("stl.gal")).read()
         f = libpysal.io.open(libpysal.examples.get_path("stl_hom.txt"))
         self.y = np.array(f.by_col["HR8893"])
 
-    def test_losh(self):
-        ls = LOSH(connectivity=self.w, inference="chi-square").fit(self.y)
-        self.assertAlmostEqual(ls.Hi[0], 0.77613471)
-        self.assertAlmostEqual(ls.pval[0], 0.22802201)
-
-
-suite = unittest.TestSuite()
-test_classes = [Losh_Tester]
-for i in test_classes:
-    a = unittest.TestLoader().loadTestsFromTestCase(i)
-    suite.addTest(a)
-
-if __name__ == "__main__":
-    runner = unittest.TextTestRunner()
-    runner.run(suite)
+    @parametrize_w
+    def test_losh(self, w):
+        ls = LOSH(connectivity=w, inference="chi-square").fit(self.y)
+        np.testing.assert_allclose(ls.Hi[0], 0.77613471)
+        np.testing.assert_allclose(ls.pval[0], 0.22802201)

--- a/esda/tests/test_silhouette.py
+++ b/esda/tests/test_silhouette.py
@@ -11,8 +11,8 @@ ATOL = libpysal.common.ATOL
 parametrize_w = pytest.mark.parametrize(
     "w",
     [
-        libpysal.weights.util.lat2W(3, 3),
-        libpysal.graph.Graph.from_W(libpysal.weights.util.lat2W(3, 3)),
+        libpysal.weights.util.lat2W(3, 3, rook=False),
+        libpysal.graph.Graph.from_W(libpysal.weights.util.lat2W(3, 3, rook=False)),
     ],
     ids=["W", "Graph"],
 )
@@ -76,7 +76,7 @@ class TestSilhouette:
             self.X, self.groups, w, metric=self.precomputed
         )
         numpy.testing.assert_allclose(known, test, rtol=RTOL, atol=ATOL)
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             silhouettes.boundary_silhouette(
                 self.X,
                 self.groups,
@@ -118,11 +118,11 @@ class TestSilhouette:
             self.X, self.groups, w, metric=self.altmetric
         )
         numpy.testing.assert_allclose(known, test, rtol=RTOL, atol=ATOL)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             silhouettes.path_silhouette(
                 self.X, self.groups, w, metric=self.precomputed
             )
-        with self.assertRaises(AssertionError):
+        with pytest.raises(AssertionError):
             silhouettes.path_silhouette(
                 self.X, self.groups, w, metric=lambda d: -self.altmetric(d)
             )
@@ -195,8 +195,11 @@ class TestSilhouette:
                 0.0,
             ]
         )
-
+        if isinstance(w, libpysal.weights.W):
+            alist = w.to_adjlist(drop_islands=True)
+        else:
+            alist = w.adjacency.drop(w.isolates).reset_index()
         test = silhouettes.silhouette_alist(
-            self.X, self.groups, w.to_adjlist(drop_islands=True)
+            self.X, self.groups, alist
         )
         numpy.testing.assert_allclose(known, test.silhouette, rtol=RTOL, atol=ATOL)

--- a/esda/tests/test_silhouette.py
+++ b/esda/tests/test_silhouette.py
@@ -1,5 +1,4 @@
-import unittest
-
+import pytest
 import libpysal
 import numpy
 from sklearn.metrics import pairwise
@@ -9,17 +8,25 @@ from .. import silhouettes
 RTOL = libpysal.common.RTOL
 ATOL = libpysal.common.ATOL
 
+parametrize_w = pytest.mark.parametrize(
+    "w",
+    [
+        libpysal.weights.util.lat2W(3, 3),
+        libpysal.graph.Graph.from_W(libpysal.weights.util.lat2W(3, 3)),
+    ],
+    ids=["W", "Graph"],
+)
 
-class Silhouette_Tester(unittest.TestCase):
-    def setUp(self):
-        self.w = libpysal.weights.lat2W(3, 3, rook=False)
+class TestSilhouette:
+    def setup_method(self):
         numpy.random.seed(12345)
         self.X = numpy.random.random((9, 3))
         self.groups = numpy.array([[0, 0, 0], [0, 1, 1], [0, 1, 1]]).flatten()
         self.precomputed = self.X @ self.X.T
         self.altmetric = pairwise.manhattan_distances
 
-    def test_boundary(self):
+    @parametrize_w
+    def test_boundary(self, w):
         known = numpy.array(
             [
                 0.03042804,
@@ -33,7 +40,7 @@ class Silhouette_Tester(unittest.TestCase):
                 0.0,
             ]
         )
-        test = silhouettes.boundary_silhouette(self.X, self.groups, self.w)
+        test = silhouettes.boundary_silhouette(self.X, self.groups, w)
         numpy.testing.assert_allclose(known, test, rtol=RTOL, atol=ATOL)
         known = numpy.array(
             [
@@ -49,7 +56,7 @@ class Silhouette_Tester(unittest.TestCase):
             ]
         )
         test = silhouettes.boundary_silhouette(
-            self.X, self.groups, self.w, metric=self.altmetric
+            self.X, self.groups, w, metric=self.altmetric
         )
         numpy.testing.assert_allclose(known, test, rtol=RTOL, atol=ATOL)
         known = numpy.array(
@@ -66,18 +73,19 @@ class Silhouette_Tester(unittest.TestCase):
             ]
         )
         test = silhouettes.boundary_silhouette(
-            self.X, self.groups, self.w, metric=self.precomputed
+            self.X, self.groups, w, metric=self.precomputed
         )
         numpy.testing.assert_allclose(known, test, rtol=RTOL, atol=ATOL)
         with self.assertRaises(AssertionError):
             silhouettes.boundary_silhouette(
                 self.X,
                 self.groups,
-                self.w,
+                w,
                 metric=self.precomputed - self.precomputed.mean(),
             )
 
-    def test_path(self):
+    @parametrize_w
+    def test_path(self, w):
         known = numpy.array(
             [
                 0.15982274,
@@ -91,7 +99,7 @@ class Silhouette_Tester(unittest.TestCase):
                 0.4165144,
             ]
         )
-        test = silhouettes.path_silhouette(self.X, self.groups, self.w)
+        test = silhouettes.path_silhouette(self.X, self.groups, w)
         numpy.testing.assert_allclose(known, test, rtol=RTOL, atol=ATOL)
         known = numpy.array(
             [
@@ -107,16 +115,16 @@ class Silhouette_Tester(unittest.TestCase):
             ]
         )
         test = silhouettes.path_silhouette(
-            self.X, self.groups, self.w, metric=self.altmetric
+            self.X, self.groups, w, metric=self.altmetric
         )
         numpy.testing.assert_allclose(known, test, rtol=RTOL, atol=ATOL)
         with self.assertRaises(TypeError):
             silhouettes.path_silhouette(
-                self.X, self.groups, self.w, metric=self.precomputed
+                self.X, self.groups, w, metric=self.precomputed
             )
         with self.assertRaises(AssertionError):
             silhouettes.path_silhouette(
-                self.X, self.groups, self.w, metric=lambda d: -self.altmetric(d)
+                self.X, self.groups, w, metric=lambda d: -self.altmetric(d)
             )
 
     def test_nearest_label(self):
@@ -141,7 +149,8 @@ class Silhouette_Tester(unittest.TestCase):
         )
         numpy.testing.assert_allclose(d, knownd, rtol=RTOL, atol=ATOL)
 
-    def test_silhouette_alist(self):
+    @parametrize_w
+    def test_silhouette_alist(self, w):
         known = numpy.array(
             [
                 0.0,
@@ -188,6 +197,6 @@ class Silhouette_Tester(unittest.TestCase):
         )
 
         test = silhouettes.silhouette_alist(
-            self.X, self.groups, self.w.to_adjlist(drop_islands=True)
+            self.X, self.groups, w.to_adjlist(drop_islands=True)
         )
         numpy.testing.assert_allclose(known, test.silhouette, rtol=RTOL, atol=ATOL)


### PR DESCRIPTION
This should be the last of the PRs ensuring that esda os Graph-ready.

Once they're all merged I'll do some minor cleanup to avoid unnecessary code duplication.