### PR TITLE
 formats, lints, pytest pt. 1 -- `test_{utils,topo}.py`

### DIFF
--- a/esda/tests/test_topo.py
+++ b/esda/tests/test_topo.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 import numpy
 import pandas
 import pytest
@@ -7,13 +5,13 @@ import pytest
 from ..topo import isolation, prominence, to_elevation, weights
 
 
-class TopoTester(TestCase):
-    def setUp(self):
+class TestTopo:
+    def setup_method(self):
         self.points = numpy.array(
             [[0, 0], [0, 1], [1, 1], [2, 0.5], [0.5, 0.5], [0.75, 0]]
         )
         self.marks = numpy.array([-1, 0.5, 1, 2, 3, 1.25])
-        self.cxn = weights.Voronoi(self.points)
+        self.cxn = weights.Voronoi(self.points, use_index=False)
 
     def test_prominence_valid(self):
         w = self.cxn
@@ -49,7 +47,6 @@ class TopoTester(TestCase):
         assert not numpy.allclose(default, middle)
 
     def test_isolation_options(self):
-
         pytest.importorskip("rtree")
 
         marks = self.marks
@@ -79,9 +76,8 @@ class TopoTester(TestCase):
         assert numpy.isnan(iso.loc[4, "parent_rank"])
         assert (iso.dropna().parent_index == 4).all()
         assert (
-            iso.sort_values("marks", ascending=False).index == (
-                iso.sort_values("rank").index
-            )
+            iso.sort_values("marks", ascending=False).index
+            == (iso.sort_values("rank").index)
         ).all()
         assert iso.loc[3, "isolation"] == 1.5
         assert iso.loc[2, "gap"] == (
@@ -97,9 +93,8 @@ class TopoTester(TestCase):
         assert numpy.isnan(iso.loc[3, "parent_index"])
         assert (iso.dropna().parent_index == [4, 2, 5, 5, 3]).all()
         assert (
-            iso.sort_values("marks", ascending=False).index == (
-                iso.sort_values("rank").index
-            )
+            iso.sort_values("marks", ascending=False).index
+            == (iso.sort_values("rank").index)
         ).all()
         assert iso.loc[1, "isolation"] == 1
         assert iso.loc[2, "gap"] == (

--- a/esda/tests/test_util.py
+++ b/esda/tests/test_util.py
@@ -1,13 +1,12 @@
-import unittest
-
 import libpysal
 import numpy as np
+import pytest
 
 from .. import moran, util
 
 
-class Fdr_Tester(unittest.TestCase):
-    def setUp(self):
+class TestFdr:
+    def setup_method(self):
         self.w = libpysal.io.open(libpysal.examples.get_path("stl.gal")).read()
         f = libpysal.io.open(libpysal.examples.get_path("stl_hom.txt"))
         self.y = np.array(f.by_col["HR8893"])
@@ -16,16 +15,5 @@ class Fdr_Tester(unittest.TestCase):
         lm = moran.Moran_Local(
             self.y, self.w, transformation="r", permutations=999, seed=10
         )
-        self.assertAlmostEqual(util.fdr(lm.p_sim, 0.1), 0.002564102564102564)
-        self.assertAlmostEqual(util.fdr(lm.p_sim, 0.05), 0.001282051282051282)
-
-
-suite = unittest.TestSuite()
-test_classes = [Fdr_Tester]
-for i in test_classes:
-    a = unittest.TestLoader().loadTestsFromTestCase(i)
-    suite.addTest(a)
-
-if __name__ == "__main__":
-    runner = unittest.TextTestRunner()
-    runner.run(suite)
+        assert pytest.approx(util.fdr(lm.p_sim, 0.1)) == 0.002564102564102564
+        assert pytest.approx(util.fdr(lm.p_sim, 0.05)) == 0.001282051282051282


### PR DESCRIPTION
This PR:
* formats, lints, and migrates to `pytest`
   * `tests/test_utils.py` 
   * `tests/test_topo.py` 

------------

xref:
* #323 
* #335