### PR TITLE
make matplotlib optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ $ pip install git+https://github.com/pysal/esda@main
 
 - `numba>=0.57` - used to accelerate computational geometry and permutation-based statistical inference.
 - `rtree>=1.0` - required for `esda.topo.isolation()`
+- `matplotlib` - required for `esda.moran.explore()`
 
 ## Contribute
 

--- a/ci/312-min.yaml
+++ b/ci/312-min.yaml
@@ -15,7 +15,6 @@ dependencies:
   - codecov
   - folium
   - mapclassify
-  - matplotlib
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -16,7 +16,6 @@ import pandas as pd
 import scipy.stats as stats
 from libpysal.weights import W
 from libpysal.weights.spatial_lag import lag_spatial
-from matplotlib import colors
 from scipy import sparse
 
 from .crand import _prepare_univariate
@@ -1785,6 +1784,11 @@ def _explore_local_moran(moran_local, gdf, crit_value, **kwargs):
     m
         folium.Map
     """
+
+    try:
+        from matplotlib import colors
+    except ImportError:
+        raise ImportError("matplotlib library must be installed to use the explore feature") from None
 
     gdf = gdf.copy()
     gdf["Moran Cluster"] = moran_local.get_cluster_labels(crit_value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Repository = "https://github.com/pysal/esda"
 
 [project.optional-dependencies]
 plus = [
+    "matplotlib",
     "numba>=0.57",
     "rtree>=1.0",
 ]
@@ -53,7 +54,6 @@ tests = [
     "codecov",
     "folium",
     "mapclassify",
-    "matplotlib",
     "pytest",
     "pytest-cov",
     "pytest-xdist",


### PR DESCRIPTION
Right now matplotlib is an implicit dependency of the library. By moving the import statement inside the function that uses it, esda will no longer break consumers that dont take a dependency on matplotlib explicitly.