### PR TITLE
Fix typo in documentation.

### DIFF
--- a/esda/moran.py
+++ b/esda/moran.py
@@ -155,6 +155,7 @@ class Moran:
     0.00027147862770937614
 
     SIDS example replicating OpenGeoda
+
     >>> w = libpysal.io.open(libpysal.examples.get_path("sids2.gal")).read()
     >>> f = libpysal.io.open(libpysal.examples.get_path("sids2.dbf"))
     >>> SIDR = np.array(f.by_col("SIDR74"))


### PR DESCRIPTION
Add a space so the Sphinx generated documentation formats properly.

https://pysal.org/esda/generated/esda.Moran.html#esda.Moran