### PR TITLE
Correct documentation

### DIFF
--- a/esda/moran.py
+++ b/esda/moran.py
@@ -67,7 +67,8 @@ class Moran:
     transformation  : string
                       weights transformation,  default is row-standardized "r".
                       Other options include "B": binary,  "D":
-                      doubly-standardized,  "O": restore original transformation
+                      doubly-standardized,  "O": restore original transformation 
+                      (applicable only if ``w`` is  passed as ``W``)
                       (general weights), "V": variance-stabilizing.
     permutations    : int
                       number of random permutations for calculation of

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -67,7 +67,7 @@ class Moran:
     transformation  : string
                       weights transformation,  default is row-standardized "r".
                       Other options include "B": binary,  "D":
-                      doubly-standardized,  "U": untransformed
+                      doubly-standardized,  "O": restore original transformation
                       (general weights), "V": variance-stabilizing.
     permutations    : int
                       number of random permutations for calculation of
@@ -337,7 +337,7 @@ class Moran_BV:  # noqa: N801
                       Other options include
                       "B": binary,
                       "D": doubly-standardized,
-                      "U": untransformed (general weights),
+                      "O": restore original transformation (general weights),
                       "V": variance-stabilizing.
     permutations    : int
                       number of random permutations for calculation of pseudo
@@ -655,7 +655,7 @@ class Moran_Rate(Moran):  # noqa: N801
                       Other options include
                       "B": binary,
                       "D": doubly-standardized,
-                      "U": untransformed (general weights),
+                      "O": restore original transformation (general weights),
                       "V": variance-stabilizing.
     two_tailed      : boolean
                       If True (default), analytical p-values for Moran's I are
@@ -889,7 +889,7 @@ class Moran_Local:  # noqa: N801
          Other options include
          "B": binary,
          "D": doubly-standardized,
-         "U": untransformed (general weights),
+         "O": restore original transformation (general weights),
          "V": variance-stabilizing.
     permutations : int
         number of random permutations for calculation of pseudo
@@ -1263,7 +1263,7 @@ class Moran_Local_BV:  # noqa: N801
         Other options include
         "B": binary,
         "D": doubly-standardized,
-        "U": untransformed (general weights),
+        "O": restore original transformation (general weights),
         "V": variance-stabilizing.
     permutations   : int
         number of random permutations for calculation of pseudo
@@ -1533,7 +1533,7 @@ class Moran_Local_Rate(Moran_Local):  # noqa: N801
         Other options include
         "B": binary,
         "D": doubly-standardized,
-        "U": untransformed (general weights),
+        "O": restore original transformation (general weights),
         "V": variance-stabilizing.
     permutations : int
         number of random permutations for calculation of pseudo

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -338,7 +338,7 @@ class Moran_BV:  # noqa: N801
                       Other options include
                       "B": binary,
                       "D": doubly-standardized,
-                      "O": restore original transformation (general weights),
+                      "O": restore original transformation (applicable only if ``w`` is  passed as ``W``),
                       "V": variance-stabilizing.
     permutations    : int
                       number of random permutations for calculation of pseudo
@@ -656,7 +656,7 @@ class Moran_Rate(Moran):  # noqa: N801
                       Other options include
                       "B": binary,
                       "D": doubly-standardized,
-                      "O": restore original transformation (general weights),
+                      "O": restore original transformation (applicable only if ``w`` is  passed as ``W``),
                       "V": variance-stabilizing.
     two_tailed      : boolean
                       If True (default), analytical p-values for Moran's I are
@@ -890,7 +890,7 @@ class Moran_Local:  # noqa: N801
          Other options include
          "B": binary,
          "D": doubly-standardized,
-         "O": restore original transformation (general weights),
+         "O": restore original transformation (applicable only if ``w`` is  passed as ``W``),
          "V": variance-stabilizing.
     permutations : int
         number of random permutations for calculation of pseudo
@@ -1264,7 +1264,7 @@ class Moran_Local_BV:  # noqa: N801
         Other options include
         "B": binary,
         "D": doubly-standardized,
-        "O": restore original transformation (general weights),
+        "O": restore original transformation (applicable only if ``w`` is  passed as ``W``),
         "V": variance-stabilizing.
     permutations   : int
         number of random permutations for calculation of pseudo
@@ -1534,7 +1534,7 @@ class Moran_Local_Rate(Moran_Local):  # noqa: N801
         Other options include
         "B": binary,
         "D": doubly-standardized,
-        "O": restore original transformation (general weights),
+        "O": restore original transformation (applicable only if ``w`` is  passed as ``W``),
         "V": variance-stabilizing.
     permutations : int
         number of random permutations for calculation of pseudo


### PR DESCRIPTION
Setting transformation to "U" causes an "unsupported weights transformation" exception because "U" is not an accepted parameter of the set_transform method of the libpysal.weights.W class. The correct argument is "O", which is described in the [libpysal.weights.W documentation](https://pysal.org/libpysal/generated/libpysal.weights.W.html#libpysal.weights.W.set_transform) as "Restore original transformation (from instantiation)". I've updated the documentation to reflect that.