### PR TITLE
add doc for z attr in Moran_Local

### DIFF
--- a/esda/moran.py
+++ b/esda/moran.py
@@ -82,6 +82,8 @@ class Moran:
                    original variable
     w            : W | Graph
                    original w object
+    z            : array
+                   zero-mean, unit standard deviation normalized y                   
     permutations : int
                    number of permutations
     I            : float


### PR DESCRIPTION
Attributes list was lacking a description of what `z` was despite it being used somewhat frequently. I added a short description. 