### PR TITLE
ENH: add Moran scatterplot ported from splot

### DIFF
--- a/esda/moran.py
+++ b/esda/moran.py
@@ -333,16 +333,16 @@ class Moran:
         Parameters
         ----------
         ax : matplotlib.axes.Axes, optional
-            Pre-existing axes for the plot, by default None
+            Pre-existing axes for the plot, by default None.
         scatter_kwds : dict, optional
-            Additional keyword arguments for scatter plot, by default None
+            Additional keyword arguments for scatter plot, by default None.
         fitline_kwds : dict, optional
-            Additional keyword arguments for fit line, by default None
+            Additional keyword arguments for fit line, by default None.
 
         Returns
         -------
         matplotlib.axes.Axes
-            Axes object with the Moran scatterplot
+            Axes object with the Moran scatterplot.
         """
         return _scatterplot(
             self,
@@ -1316,18 +1316,18 @@ class Moran_Local:  # noqa: N801
         Parameters
         ----------
         crit_value : float, optional
-            Critical value to determine statistical significance, by default 0.05
+            Critical value to determine statistical significance, by default 0.05.
         ax : matplotlib.axes.Axes, optional
-            Pre-existing axes for the plot, by default None
+            Pre-existing axes for the plot, by default None.
         scatter_kwds : dict, optional
-            Additional keyword arguments for scatter plot, by default None
+            Additional keyword arguments for scatter plot, by default None.
         fitline_kwds : dict, optional
-            Additional keyword arguments for fit line, by default None
+            Additional keyword arguments for fit line, by default None.
 
         Returns
         -------
         matplotlib.axes.Axes
-            Axes object with the Moran scatterplot
+            Axes object with the Moran scatterplot.
         """
         return _scatterplot(
             self,
@@ -1920,36 +1920,35 @@ def _moran_loc_scatterplot(
     fitline_kwds=None,
 ):
     """
-    Moran Scatterplot with option of coloring of Local Moran Statistics
+    Moran Scatterplot with option of coloring of Local Moran Statistics.
 
     Parameters
     ----------
     moran_loc : esda.moran.Moran_Local instance
-        Values of Moran's I Local Autocorrelation Statistics
+        Values of Moran's I Local Autocorrelation Statistics.
     p : float, optional
         If given, the p-value threshold for significance. Points will
-        be colored by significance. By default it will not be colored.
-        Default =None.
+        be colored by significance. By default it will not be colored,
+        by default None.
     aspect_equal : bool, optional
         If True, Axes of Moran Scatterplot will show the same
         aspect or visual proportions.
     ax : Matplotlib Axes instance, optional
-        If given, the Moran plot will be created inside this axis.
-        Default =None.
+        If given, the Moran plot will be created inside this axis,
+        by default None.
     scatter_kwds : keyword arguments, optional
-        Keywords used for creating and designing the scatter points.
-        Default =None.
+        Keywords used for creating and designing the scatter points,
+        by default None.
     fitline_kwds : keyword arguments, optional
-        Keywords used for creating and designing the moran fitline.
-        Default =None.
+        Keywords used for creating and designing the moran fitline,
+        by default None.
 
     Returns
     -------
     fig : Matplotlib Figure instance
-        Moran Local scatterplot figure
+        Moran Local scatterplot figure.
     ax : matplotlib Axes instance
-        Axes in which the figure is plotted
-
+        Axes in which the figure is plotted.
     """
 
 

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -321,7 +321,7 @@ class Moran:
             **stat_kws,
         )
 
-    def plot_scatterplot(
+    def plot_scatter(
         self,
         ax=None,
         scatter_kwds=None,
@@ -1303,7 +1303,7 @@ class Moran_Local:  # noqa: N801
         gdf["Moran Cluster"] = self.get_cluster_labels(crit_value)
         return _viz_local_moran(self, gdf, crit_value, "plot", **kwargs)
 
-    def plot_scatterplot(
+    def plot_scatter(
         self,
         crit_value=0.05,
         ax=None,

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -1279,12 +1279,30 @@ class Moran_Local:  # noqa: N801
         scatter_kwds=None,
         fitline_kwds=None,
     ):
+        """
+        Plot a Moran scatterplot with optional coloring for significant points.
+
+        Parameters
+        ----------
+        crit_value : float, optional
+            Critical value to determine statistical significance, by default 0.05
+        ax : matplotlib.axes.Axes, optional
+            Pre-existing axes for the plot, by default None
+        scatter_kwds : dict, optional
+            Additional keyword arguments for scatter plot, by default None
+        fitline_kwds : dict, optional
+            Additional keyword arguments for fit line, by default None
+
+        Returns
+        -------
+        matplotlib.axes.Axes
+            Axes object with the Moran scatterplot
+        """
         try:
-            from matplotlib import colors
             from matplotlib import pyplot as plt
         except ImportError as err:
             raise ImportError(
-                "matplotlib library must be installed to use the vizualization feature"
+                "matplotlib library must be installed to use the scatterplot feature"
             ) from err
 
         # to set default as an empty dictionary that is later filled with defaults

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -1912,46 +1912,6 @@ def _viz_local_moran(moran_local, gdf, crit_value, method, **kwargs):
     )
 
 
-def _moran_loc_scatterplot(
-    moran_loc,
-    crit_value=None,
-    ax=None,
-    scatter_kwds=None,
-    fitline_kwds=None,
-):
-    """
-    Moran Scatterplot with option of coloring of Local Moran Statistics.
-
-    Parameters
-    ----------
-    moran_loc : esda.moran.Moran_Local instance
-        Values of Moran's I Local Autocorrelation Statistics.
-    p : float, optional
-        If given, the p-value threshold for significance. Points will
-        be colored by significance. By default it will not be colored,
-        by default None.
-    aspect_equal : bool, optional
-        If True, Axes of Moran Scatterplot will show the same
-        aspect or visual proportions.
-    ax : Matplotlib Axes instance, optional
-        If given, the Moran plot will be created inside this axis,
-        by default None.
-    scatter_kwds : keyword arguments, optional
-        Keywords used for creating and designing the scatter points,
-        by default None.
-    fitline_kwds : keyword arguments, optional
-        Keywords used for creating and designing the moran fitline,
-        by default None.
-
-    Returns
-    -------
-    fig : Matplotlib Figure instance
-        Moran Local scatterplot figure.
-    ax : matplotlib Axes instance
-        Axes in which the figure is plotted.
-    """
-
-
 def _get_cluster_labels(moran_local, crit_value):
     gdf = pd.DataFrame()
     gdf["q"] = moran_local.q
@@ -1975,6 +1935,32 @@ def _scatterplot(
     scatter_kwds=None,
     fitline_kwds=None,
 ):
+    """Generates a Moran Local or Global Scatterplot.
+
+    Parameters
+    ----------
+    moran : Moran object
+        An instance of a Moran or Moran_Local object.
+    crit_value : float, optional
+        The critical value for significance. Default is 0.05.
+    ax : matplotlib.axes.Axes, optional
+        The axes on which to draw the plot. If None, a new figure and axes are created.
+    scatter_kwds : dict, optional
+        Additional keyword arguments to pass to the scatter plot.
+    fitline_kwds : dict, optional
+        Additional keyword arguments to pass to the fit line plot.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        The axes with the Moran Scatterplot.
+
+    Raises
+    ------
+    ImportError
+        If matplotlib is not installed.
+    """
+
     try:
         from matplotlib import pyplot as plt
     except ImportError as err:

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -115,6 +115,58 @@ class TestMoran:
         np.testing.assert_allclose(sidr, 0.24772519320480135, atol=ATOL, rtol=RTOL)
         np.testing.assert_allclose(pval, 0.001)
 
+    @parametrize_sac
+    def test_Moran_plot_scatterplot(self, w):
+        import matplotlib
+
+        matplotlib.use("Agg")
+
+        m = moran.Moran(
+            sac1.WHITE,
+            w,
+        )
+
+        ax = m.plot_scatterplot()
+
+        # test scatter
+        np.testing.assert_array_almost_equal(
+            ax.collections[0].get_facecolors(),
+            np.array([[0.729412, 0.729412, 0.729412, 0.6]]),
+        )
+
+        # test fitline
+        l = ax.lines[2]
+        x, y = l.get_data()
+        np.testing.assert_almost_equal(x.min(), -1.8236414387225368)
+        np.testing.assert_almost_equal(x.max(), 3.893056527659032)
+        np.testing.assert_almost_equal(y.min(), -0.7371749399524187)
+        np.testing.assert_almost_equal(y.max(), 1.634939204358587)
+        assert l.get_color() == "#d6604d"
+
+    @parametrize_sac
+    def test_Moran_plot_scatterplot_args(self, w):
+        import matplotlib
+
+        matplotlib.use("Agg")
+
+        m = moran.Moran(
+            sac1.WHITE,
+            w,
+        )
+
+        ax = m.plot_scatterplot(scatter_kwds=dict(color='blue'), fitline_kwds=dict(color='pink'))
+
+        # test scatter
+        np.testing.assert_array_almost_equal(
+            ax.collections[0].get_facecolors(),
+            np.array([[0, 0, 1, 0.6]]),
+        )
+
+        # test fitline
+        l = ax.lines[2]
+        assert l.get_color() == "pink"
+
+
 
 class TestMoranRate:
     def setup_method(self):

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -116,7 +116,7 @@ class TestMoran:
         np.testing.assert_allclose(pval, 0.001)
 
     @parametrize_sac
-    def test_Moran_plot_scatterplot(self, w):
+    def test_Moran_plot_scatter(self, w):
         import matplotlib
 
         matplotlib.use("Agg")
@@ -126,7 +126,7 @@ class TestMoran:
             w,
         )
 
-        ax = m.plot_scatterplot()
+        ax = m.plot_scatter()
 
         # test scatter
         np.testing.assert_array_almost_equal(
@@ -144,7 +144,7 @@ class TestMoran:
         assert l.get_color() == "#d6604d"
 
     @parametrize_sac
-    def test_Moran_plot_scatterplot_args(self, w):
+    def test_Moran_plot_scatter_args(self, w):
         import matplotlib
 
         matplotlib.use("Agg")
@@ -154,7 +154,7 @@ class TestMoran:
             w,
         )
 
-        ax = m.plot_scatterplot(scatter_kwds=dict(color='blue'), fitline_kwds=dict(color='pink'))
+        ax = m.plot_scatter(scatter_kwds=dict(color='blue'), fitline_kwds=dict(color='pink'))
 
         # test scatter
         np.testing.assert_array_almost_equal(
@@ -321,7 +321,7 @@ class TestMoranLocal:
         np.testing.assert_array_equal(counts, np.array([86, 3, 298, 38, 3]))
 
     @parametrize_sac
-    def test_Moran_Local_plot_scatterplot(self, w):
+    def test_Moran_Local_plot_scatter(self, w):
         import matplotlib
 
         matplotlib.use("Agg")
@@ -335,7 +335,7 @@ class TestMoranLocal:
             seed=SEED,
         )
 
-        ax = lm.plot_scatterplot()
+        ax = lm.plot_scatter()
 
         # test scatter
         unique, counts = np.unique(
@@ -365,7 +365,7 @@ class TestMoranLocal:
         assert l.get_color() == "k"
 
     @parametrize_sac
-    def test_Moran_Local_plot_scatterplot_args(self, w):
+    def test_Moran_Local_plot_scatter_args(self, w):
         import matplotlib
 
         matplotlib.use("Agg")
@@ -379,7 +379,7 @@ class TestMoranLocal:
             seed=SEED,
         )
 
-        ax = lm.plot_scatterplot(
+        ax = lm.plot_scatter(
             crit_value=None,
             scatter_kwds={"s": 10},
             fitline_kwds={"linewidth": 4},

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -251,15 +251,98 @@ class TestMoranLocal:
             seed=SEED,
         )
         ax = lm.plot(sac1)
-        unique, counts = np.unique(ax.collections[0].get_facecolors(), axis=0, return_counts=True)
-        np.testing.assert_array_almost_equal(unique, np.array([
-            [0.17254902, 0.48235294, 0.71372549, 1.],
-            [0.5372549 , 0.81176471, 0.94117647, 1.],
-            [0.82745098, 0.82745098, 0.82745098, 1.],
-            [0.84313725, 0.09803922, 0.10980392, 1.],
-            [0.99215686, 0.68235294, 0.38039216, 1.]]
-        ))
-        np.testing.assert_array_equal(counts, np.array([86,3, 298,38, 3]))
+        unique, counts = np.unique(
+            ax.collections[0].get_facecolors(), axis=0, return_counts=True
+        )
+        np.testing.assert_array_almost_equal(
+            unique,
+            np.array(
+                [
+                    [0.17254902, 0.48235294, 0.71372549, 1.0],
+                    [0.5372549, 0.81176471, 0.94117647, 1.0],
+                    [0.82745098, 0.82745098, 0.82745098, 1.0],
+                    [0.84313725, 0.09803922, 0.10980392, 1.0],
+                    [0.99215686, 0.68235294, 0.38039216, 1.0],
+                ]
+            ),
+        )
+        np.testing.assert_array_equal(counts, np.array([86, 3, 298, 38, 3]))
+
+    @parametrize_sac
+    def test_Moran_Local_plot_scatterplot(self, w):
+        import matplotlib
+
+        matplotlib.use("Agg")
+
+        lm = moran.Moran_Local(
+            sac1.WHITE,
+            w,
+            transformation="r",
+            permutations=99,
+            keep_simulations=True,
+            seed=SEED,
+        )
+
+        ax = lm.plot_scatterplot()
+
+        # test scatter
+        unique, counts = np.unique(
+            ax.collections[0].get_facecolors(), axis=0, return_counts=True
+        )
+        np.testing.assert_array_almost_equal(
+            unique,
+            np.array(
+                [
+                    [0.17254902, 0.48235294, 0.71372549, 0.6],
+                    [0.5372549, 0.81176471, 0.94117647, 0.6],
+                    [0.82745098, 0.82745098, 0.82745098, 0.6],
+                    [0.84313725, 0.09803922, 0.10980392, 0.6],
+                    [0.99215686, 0.68235294, 0.38039216, 0.6],
+                ]
+            ),
+        )
+        np.testing.assert_array_equal(counts, np.array([73, 12, 261, 52, 5]))
+
+        # test fitline
+        l = ax.lines[2]
+        x, y = l.get_data()
+        np.testing.assert_almost_equal(x.min(), -1.8236414387225368)
+        np.testing.assert_almost_equal(x.max(), 3.893056527659032)
+        np.testing.assert_almost_equal(y.min(), -0.7371749399524187)
+        np.testing.assert_almost_equal(y.max(), 1.634939204358587)
+        assert l.get_color() == "k"
+
+    @parametrize_sac
+    def test_Moran_Local_plot_scatterplot_args(self, w):
+        import matplotlib
+
+        matplotlib.use("Agg")
+
+        lm = moran.Moran_Local(
+            sac1.WHITE,
+            w,
+            transformation="r",
+            permutations=99,
+            keep_simulations=True,
+            seed=SEED,
+        )
+
+        ax = lm.plot_scatterplot(
+            crit_value=None,
+            scatter_kwds={"s": 10},
+            fitline_kwds={"linewidth": 4},
+        )
+        # test scatter
+        np.testing.assert_array_almost_equal(
+            ax.collections[0].get_facecolors(),
+            np.array([[0.729412, 0.729412, 0.729412, 0.6]]),
+        )
+        assert ax.collections[0].get_sizes()[0] == 10
+
+        # test fitline
+        l = ax.lines[2]
+        assert l.get_color() == "#d6604d"
+        assert l.get_linewidth() == 4.0
 
     @parametrize_desmith
     def test_Moran_Local_parallel(self, w):


### PR DESCRIPTION
This adds a method to plot a scatterplot from Moran_Local and Moran based on the splot implementation with some changes. 

1. It is more restricted - always use standardised values, always enforce equal aspect
2. Limited figure customisation - splot has opinionated style of axes. Leaving this to a user here.
3. Rely on scipy to do the regression to avoid additional dependency on spreg.

As a follow up, I want to figure out a smart way of colour customisation but didn't give it much thought yet.

Regarding the API, should we go with `plot_scatterplot` or just simply `scatterplot`?