### PR TITLE
restart work on linting+formatting testing suite & migrate to pytest – part 1

### DIFF
--- a/esda/tests/test_crand.py
+++ b/esda/tests/test_crand.py
@@ -8,9 +8,9 @@ def test_vec_permutations_basic():
     """Test vec_permutations with basic input."""
     result = vec_permutations(5, 24, 10, seed=12345)
     assert len(result) == 10, "Should create 10 permutations"
-    assert all(
-        isinstance(item, np.ndarray) for item in result
-    ), "Each permutation should be an array"
+    assert all(isinstance(item, np.ndarray) for item in result), (
+        "Each permutation should be an array"
+    )
     expected = np.array(
         [
             [10, 19, 8, 17, 3],

--- a/esda/tests/test_gamma.py
+++ b/esda/tests/test_gamma.py
@@ -1,10 +1,8 @@
+import libpysal
+import numpy as np
 import pytest
 
-import numpy as np
-import libpysal
-
 from ..gamma import Gamma
-
 
 parametrize_lat = pytest.mark.parametrize(
     "w",
@@ -25,8 +23,7 @@ class TestGamma:
         np.random.seed(12345)
 
     @parametrize_lat
-    def test_Gamma(self, w):
-        """Test method"""
+    def test_default(self, w):
         g = Gamma(self.y, w)
 
         np.testing.assert_allclose(g.g, 20.0)
@@ -37,7 +34,7 @@ class TestGamma:
         np.testing.assert_allclose(g.mean_g, 11.093093093093094)
 
     @parametrize_lat
-    def test_Gamma_s(self, w):
+    def test_s(self, w):
         np.random.seed(12345)
         g1 = Gamma(self.y, w, operation="s")
         np.testing.assert_allclose(g1.g, 8.0)
@@ -48,7 +45,7 @@ class TestGamma:
         np.testing.assert_allclose(g1.mean_g, 25.623623623623622)
 
     @parametrize_lat
-    def test_Gamma_a(self, w):
+    def test_a(self, w):
         np.random.seed(12345)
         g2 = Gamma(self.y, w, operation="a")
         np.testing.assert_allclose(g2.g, 8.0)
@@ -59,7 +56,7 @@ class TestGamma:
         np.testing.assert_allclose(g2.mean_g, 25.623623623623622)
 
     @parametrize_lat
-    def test_Gamma_standardize(self, w):
+    def test_standardize(self, w):
         np.random.seed(12345)
         g3 = Gamma(self.y, w, standardize=True)
         np.testing.assert_allclose(g3.g, 32.0)
@@ -70,7 +67,7 @@ class TestGamma:
         np.testing.assert_allclose(g3.mean_g, -3.2472472472472473)
 
     @parametrize_lat
-    def test_Gamma_op(self, w):
+    def test_op(self, w):
         np.random.seed(12345)
         if isinstance(w, libpysal.graph.Graph):
             pytest.skip("Calleble not supported with Graph")

--- a/esda/tests/test_geary.py
+++ b/esda/tests/test_geary.py
@@ -1,10 +1,10 @@
 """Geary Unittest."""
 
 import numpy as np
+import pytest
 from libpysal import examples, graph
 from libpysal.io import open as popen
 from libpysal.weights import Rook
-import pytest
 
 from .. import geary
 
@@ -29,7 +29,7 @@ class TestGeary:
         self.y = np.array(f.by_col["CRIME"])
 
     @parametrize_w
-    def test_Geary(self, w):
+    def test_default(self, w):
         c = geary.Geary(self.y, w, permutations=0)
         np.testing.assert_allclose(c.C, 0.5154408058652411)
         np.testing.assert_allclose(c.EC, 1.0)

--- a/esda/tests/test_getisord.py
+++ b/esda/tests/test_getisord.py
@@ -24,7 +24,7 @@ class TestGetisG:
         np.random.seed(10)
 
     @parametrize_w
-    def test_G(self, w):
+    def test_default(self, w):
         g = getisord.G(self.y, w)
         np.testing.assert_allclose(g.G, 0.55709779, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(g.p_norm, 0.172936, rtol=RTOL, atol=ATOL)
@@ -50,20 +50,20 @@ class TestGLocal:
         np.random.seed(10)
 
     @parametrize_w
-    def test_G_Local_Binary(self, w):
+    def test_binary(self, w):
         lg = getisord.G_Local(self.y, w, transform="B", seed=10)
         np.testing.assert_allclose(lg.Zs[0], -1.0136729, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(lg.p_sim[0], 0.102, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(lg.p_z_sim[0], 0.153923, rtol=RTOL, atol=ATOL)
 
     @parametrize_w
-    def test_G_Local_Row_Standardized(self, w):
+    def test_row_standardized(self, w):
         lg = getisord.G_Local(self.y, w, transform="R", seed=10)
         np.testing.assert_allclose(lg.Zs[0], -0.62074534, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(lg.p_sim[0], 0.102, rtol=RTOL, atol=ATOL)
 
     @parametrize_w
-    def test_G_star_Local_Binary(self, w):
+    def test_star_binary(self, w):
         lg = getisord.G_Local(self.y, w, transform="B", star=True, seed=10)
         np.testing.assert_allclose(lg.Zs[0], -1.39727626, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(lg.p_sim[0], 0.102, rtol=RTOL, atol=ATOL)
@@ -72,12 +72,12 @@ class TestGLocal:
     @pytest.mark.xfail(
         reason="Intermittently does not warn for W param; reason unknown; see gh#331"
     )
-    def test_G_star_Row_Standardized_warning(self, w):
+    def test_star_row_standardized_warning(self, w):
         with pytest.warns(UserWarning, match="Gi\\* requested, but"):
-            lg = getisord.G_Local(self.y, w, transform="R", star=True, seed=10)
+            getisord.G_Local(self.y, w, transform="R", star=True, seed=10)
 
     @parametrize_w
-    def test_G_star_Row_Standardized_values(self, w):
+    def test_star_row_standardized_values(self, w):
         lg = getisord.G_Local(self.y, w, transform="R", star=True, seed=10)
         np.testing.assert_allclose(lg.Zs[0], -0.62488094, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(lg.p_sim[0], 0.102, rtol=RTOL, atol=ATOL)

--- a/esda/tests/test_join_counts.py
+++ b/esda/tests/test_join_counts.py
@@ -1,7 +1,7 @@
 import numpy as np
-from libpysal.weights.util import lat2W
-from libpysal import graph
 import pytest
+from libpysal import graph
+from libpysal.weights.util import lat2W
 
 from ..join_counts import Join_Counts
 
@@ -9,12 +9,11 @@ parametrize_w = pytest.mark.parametrize(
     "w",
     [
         lat2W(4, 4),
-        graph.Graph.from_W(
-             lat2W(4, 4)
-        ),
+        graph.Graph.from_W(lat2W(4, 4)),
     ],
     ids=["W", "Graph"],
 )
+
 
 class TestJoinCounts:
     """Unit test for Join Counts"""
@@ -24,7 +23,7 @@ class TestJoinCounts:
         self.y[0:8] = 0
 
     @parametrize_w
-    def test_Join_Counts(self, w):
+    def test_default(self, w):
         """Test method"""
         np.random.seed(12345)
         jc = Join_Counts(self.y, w)


### PR DESCRIPTION
* Continuing maint work for linting+formatting testing suite and converting fully to `pytest`
* xref
  * #323 
  * #335  