### PR TITLE
fix(#428): convert strict raise DeprecationWarning to warnings.warn in smoothing.py

### DIFF
--- a/esda/smoothing.py
+++ b/esda/smoothing.py
@@ -1852,7 +1852,11 @@ class Headbanging_Triples:  # noqa: N801
     """
 
     def __init__(self, data, w, k=5, t=3, angle=135.0, edgecor=False):
-        raise DeprecationWarning("Deprecated")
+        warnings.warn(
+            "Headbanging_Triples is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if k < 3:
             raise ValueError(
                 "`w` should be a `NeareastNeighbors` instance & "
@@ -2026,7 +2030,11 @@ class Headbanging_Median_Rate:  # noqa: N801
     """
 
     def __init__(self, e, b, t, aw=None, iteration=1):
-        raise DeprecationWarning("Deprecated")
+        warnings.warn(
+            "Headbanging_Median_Rate is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.r = e * 1.0 / b
         self.tr, self.aw = t.triples, aw
         if hasattr(t, "extra"):

--- a/esda/smoothing.py
+++ b/esda/smoothing.py
@@ -1854,7 +1854,7 @@ class Headbanging_Triples:  # noqa: N801
     def __init__(self, data, w, k=5, t=3, angle=135.0, edgecor=False):
         warnings.warn(
             "Headbanging_Triples is deprecated and will be removed in a future release.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         if k < 3:
@@ -1977,11 +1977,8 @@ class Headbanging_Median_Rate:  # noqa: N801
     >>> if not sids_w.id_order_set: sids_w.id_order = sids_w.id_order # doctest: +SKIP
 
     finding headbanging triples by using 5 neighbors
-        return outdf
 
     >>> s_ht = Headbanging_Triples(sids_d,sids_w,k=5) # doctest: +SKIP
-
-    DeprecationWarning: Deprecated
 
     reading in the sids2 data table
 
@@ -2032,7 +2029,7 @@ class Headbanging_Median_Rate:  # noqa: N801
     def __init__(self, e, b, t, aw=None, iteration=1):
         warnings.warn(
             "Headbanging_Median_Rate is deprecated and will be removed in a future release.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         self.r = e * 1.0 / b


### PR DESCRIPTION
fixes #428.

This pull request addresses a bug in [esda/smoothing.py] where the [Headbanging_Triples] and [Headbanging_Median_Rate] classes were abruptly halting execution rather than issuing a standard warning. Previously, the code used a strict `raise DeprecationWarning("Deprecated")` statement, which threw an exception that instantly broke users' scripts when they tried to instantiate these classes. I have swapped out the fatal `raise` keyword for the correct `warnings.warn` method, alongside a much clearer message explicitly stating that the components will be removed in a future release. Now, users will see the proper warning output in their console advising them of the deprecation, but their code will continue executing without crashing.