### PR TITLE
Fix to calculation of normalized mass moment of inertia (in `moment_of_inertia_regions` function)

### DIFF
--- a/esda/shape.py
+++ b/esda/shape.py
@@ -662,9 +662,6 @@ def moment_of_inertia_regions(collection, normalize=False, ref_pt=None,
         that each geometry is assigned to, or the name of a column in the 
         GeoDataFrame to use for region assignment. If None (default), moment of inertia 
         is calculated for each geometry in `collection` without regionalization.
-        Note that if both `regions` and `weights` are provided, the moment of 
-        inertia is calculated using the discrete approximation, i.e. assuming
-        mass is concentrated at the centroid of each geometry.
     weights : array-like, optional
         An iterable of weights (e.g., population) of the same length as 
         `collection` that are applied to each geometry in `collection`, or the 
@@ -725,9 +722,8 @@ def moment_of_inertia_regions(collection, normalize=False, ref_pt=None,
         I = \\sum_{i} m_i r_i^2
 
     where :math:`r_i` is the distance from the point to a reference point, 
-    :math:`m_i` is the mass at each point, and each point represents the 
-    centroid of a subarea of the shape, or, for a continuous shape, there are 
-    an infinite number of points filling the shape.
+    :math:`m_i` is the mass at each point, and there are an infinite number 
+    of points filling the shape.
 
     The mass moment of inertia can be calculated for an area of uniform density 
     or an area of varying density. For areas of uniform density, this is the 
@@ -744,10 +740,14 @@ def moment_of_inertia_regions(collection, normalize=False, ref_pt=None,
     and :math:`m` and :math:`A` are the mass and area of the shape, respectively.
 
     For a region of varying density, region identifiers must be provided via 
-    the `regions` parameter. :math:`I` is calculated per the equation above, 
-    with each geometry in `collection` representing a subarea with mass given
-    by `weights`. Weights are assumed to be massed at the centroid of each 
-    subregion (which is a discrete approximation), scaled by the area of each geometry.
+    the `regions` parameter. :math:`I_M` is calculated for each geometry in 
+    `collection` per the equation above, with each geometry representing a 
+    subarea of the region with mass given
+    by `weights`. The mass moment of inertia of the region is then the sum of 
+    the mass moments of inertia of each subarea shifted to the reference point
+    (using the parallel axis theorem) by adding :math:`m d^2`, where :math:`d` 
+    is the distance from the centroid of each subarea to the reference point 
+    for the region.
 
     If reference points are not provided, the mass moment of inertia is 
     calculated with respect to the centroid of each region (calculated by the

--- a/esda/shape.py
+++ b/esda/shape.py
@@ -898,7 +898,7 @@ def moment_of_inertia_regions(collection, normalize=False, ref_pt=None,
             # Area and centroid of region
             A = numpy.sum(a)
             C = numpy.sum(m[:, None] * c, axis=0) / m.sum()
-
+            print(f"Region {region}: A={A}, C={C}, m.sum()={m.sum()}")
             # Determine reference point for shifting, or use centroid
             if ref_pt is None:
                 # Use centroid
@@ -913,7 +913,7 @@ def moment_of_inertia_regions(collection, normalize=False, ref_pt=None,
             # Distance squared, don't actually need distance, so don't bother taking square root
             d2 = numpy.sum((c - pt)**2, axis=1)
 
-            J = numpy.sum(J + m * d2)
+            J = numpy.sum((m / a) * J + m * d2)
 
             if normalize:
                 J = m.sum() * A / (2 * numpy.pi * J)

--- a/esda/shape.py
+++ b/esda/shape.py
@@ -898,7 +898,7 @@ def moment_of_inertia_regions(collection, normalize=False, ref_pt=None,
             # Area and centroid of region
             A = numpy.sum(a)
             C = numpy.sum(m[:, None] * c, axis=0) / m.sum()
-            print(f"Region {region}: A={A}, C={C}, m.sum()={m.sum()}")
+
             # Determine reference point for shifting, or use centroid
             if ref_pt is None:
                 # Use centroid

--- a/esda/tests/test_shape.py
+++ b/esda/tests/test_shape.py
@@ -259,7 +259,7 @@ def test_mir_with_regions_and_weights():
     observed = numpy.asarray(esda.shape.moment_of_inertia_regions(test_region_8x8, regions=regions, weights=masses))
     testing.assert_allclose(
         observed,
-        [ 162.17647059, 6098.74074074, 2632.25      , 2657.23943662],
+        [ 189.50980392, 6185.74074074, 2709.58333333, 2771.57276995],
         atol=ATOL,
     )
 def test_mir_with_regions_and_ref_pts():


### PR DESCRIPTION
Fix for #437 .

Normalized mass moment of inertia is calculated with:

`moment_of_inertia_regions(geometry_array, normalize=True, regions=<geom region assignment>, weights=<geom weight>)`

Error was discovered in that the moment of inertia calculated for each geometry in the region was not adjusted for its mass (weight) and area. Depending upon the CRS, the area adjustment could be large. The mass moment of inertia for the reference circle was calculated correctly, because the formula is very straightforward ($mA/2\pi$).

The NMMI is the MMI of the reference circle divided by the (nonnormalized) MMI of the region. The following is a general strategy for confirming the expected NMMI with any input geometry.

Assume a geodataframe `gdf` with region assignments in the column `"region"` and weights in the column `"mass"`.

```python
import numpy as np
import geopandas as gpd
import shapely
import esda

# Calculate nonnormalized MOI of region
region_moi = esda.shape.moment_of_inertia_regions(gdf, regions="region", weights="mass").values

# Calculate areas and masses of regions for MOI of reference disc
masses = gdf.groupby("region")["mass"].sum().values
gdf["area"] = gdf.geometry.area
areas = gdf.groupby("region")["area"].sum().values
ref_disc = shapely.Point(0,0).buffer(np.sqrt(areas / np.pi))

# Calculate MOI of reference disc
ref_disc_moi = esda.shape.moment_of_inertia(ref_disc) * masses / areas

# Calculate NMMI manually and using function
nmmi_manual = ref_disc_moi / region_moi
nmmi_function = esda.shape.moment_of_inertia_regions(gdf, normalize=True, regions="region", weights="mass").values

# Calculate proportion difference between manual calculation and function
(nmmi_manual - nmmi_function) / nmmi_function
```

When executed on the virginia counties built-in dataset with counties grouped by Virginia economic regions, the manually calculated NMMI was 0.3% smaller than the NMMI calculated by the function.