### PR TITLE
Use numpy rng in moran module

### DIFF
--- a/esda/moran.py
+++ b/esda/moran.py
@@ -528,9 +528,9 @@ class Moran_BV:  # noqa: N801
         w = _transform(w, transformation)
         self.w = w
         self.I = self.__calc(zy)  # noqa: E741
+        rng = np.random.default_rng()
         if permutations:
-            nrp = np.random.permutation
-            sim = [self.__calc(nrp(zy)) for i in range(permutations)]
+            sim = [self.__calc(rng.permutation(zy)) for i in range(permutations)]
             self.sim = sim = np.array(sim)
             above = sim >= self.I
             larger = above.sum()

--- a/esda/moran.py
+++ b/esda/moran.py
@@ -514,7 +514,9 @@ class Moran_BV:  # noqa: N801
 
     """  # noqa: E501
 
-    def __init__(self, x, y, w, transformation="r", permutations=PERMUTATIONS):
+    def __init__(
+        self, x, y, w, transformation="r", permutations=PERMUTATIONS, seed=None
+    ):
         x = np.asarray(x).flatten()
         y = np.asarray(y).flatten()
         zy = (y - y.mean()) / y.std(ddof=1)
@@ -528,7 +530,7 @@ class Moran_BV:  # noqa: N801
         w = _transform(w, transformation)
         self.w = w
         self.I = self.__calc(zy)  # noqa: E741
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(seed)
         if permutations:
             sim = [self.__calc(rng.permutation(zy)) for i in range(permutations)]
             self.sim = sim = np.array(sim)
@@ -1014,6 +1016,7 @@ class Moran_Rate(Moran):  # noqa: N801
         transformation="r",
         permutations=PERMUTATIONS,
         two_tailed=True,
+        seed=None,
     ):
         e = np.asarray(e).flatten()
         b = np.asarray(b).flatten()
@@ -1025,6 +1028,7 @@ class Moran_Rate(Moran):  # noqa: N801
             transformation=transformation,
             permutations=permutations,
             two_tailed=two_tailed,
+            seed=seed,
         )
 
     @classmethod

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -287,6 +287,45 @@ class TestMoranRate:
         np.testing.assert_allclose(sidr, 0.16622343552567395, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(pval, 0.008)
 
+    @parametrize_sids
+    def test_seed_reproducibility(self, w):
+        mi1 = moran.Moran_Rate(self.e, self.b, w, permutations=99, seed=SEED)
+        mi2 = moran.Moran_Rate(self.e, self.b, w, permutations=99, seed=SEED)
+        np.testing.assert_allclose(mi1.I, mi2.I)
+        np.testing.assert_allclose(mi1.p_sim, mi2.p_sim)
+        np.testing.assert_array_equal(mi1.sim, mi2.sim)
+
+    @parametrize_sids
+    def test_seed_different_values(self, w):
+        mi1 = moran.Moran_Rate(self.e, self.b, w, permutations=99, seed=SEED)
+        mi2 = moran.Moran_Rate(self.e, self.b, w, permutations=99, seed=SEED + 1)
+        np.testing.assert_allclose(mi1.I, mi2.I)
+        assert mi1.p_sim != mi2.p_sim
+        assert not np.allclose(mi1.sim, mi2.sim)
+
+
+class TestMoranBV:
+    def setup_method(self):
+        f = libpysal.io.open(libpysal.examples.get_path("sids2.dbf"))
+        self.x = np.array(f.by_col["SIDR79"])
+        self.y = np.array(f.by_col["SIDR74"])
+
+    @parametrize_sids
+    def test_seed_reproducibility(self, w):
+        mbv1 = moran.Moran_BV(self.x, self.y, w, permutations=99, seed=SEED)
+        mbv2 = moran.Moran_BV(self.x, self.y, w, permutations=99, seed=SEED)
+        np.testing.assert_allclose(mbv1.I, mbv2.I)
+        np.testing.assert_allclose(mbv1.p_sim, mbv2.p_sim)
+        np.testing.assert_array_equal(mbv1.sim, mbv2.sim)
+
+    @parametrize_sids
+    def test_seed_different_values(self, w):
+        mbv1 = moran.Moran_BV(self.x, self.y, w, permutations=99, seed=SEED)
+        mbv2 = moran.Moran_BV(self.x, self.y, w, permutations=99, seed=SEED + 1)
+        np.testing.assert_allclose(mbv1.I, mbv2.I)
+        assert mbv1.p_sim != mbv2.p_sim
+        assert not np.allclose(mbv1.sim, mbv2.sim)
+
 
 class TestMoranBVmatrix:
     def setup_method(self):


### PR DESCRIPTION
## Summary
Added seed parameter to Moran_BV and Moran_Rate to enable reproducible permutation-based significance testing, and update Moran_BV to use the NumPy Generator API.

## Changes
`esda/moran.py`:
- Moran_BV: replaced legacy np.random.permutation with np.random.default_rng(seed).permutation(), added seed parameter
- Moran_Rate: added seed parameter, forwarded to Moran.__init__

`esda/tests/test_moran.py`:
- Added TestMoranBV class with test_seed_reproducibility and test_seed_different_values
- Added same two seed tests to TestMoranRate