### PR TITLE
mark `by_col()` methods as deprecated

### DIFF
--- a/esda/moran.py
+++ b/esda/moran.py
@@ -313,6 +313,13 @@ class Moran:
         the relevant columns attached.
 
         """
+
+        msg = (
+            "The `.by_col()` methods are deprecated and will be "
+            "removed in a future version of `esda`."
+        )
+        warn(msg, FutureWarning, stacklevel=2)
+
         return _univariate_handler(
             df,
             cols,
@@ -609,6 +616,13 @@ class Moran_BV:
         the relevant columns attached.
 
         """
+
+        msg = (
+            "The `.by_col()` methods are deprecated and will be "
+            "removed in a future version of `esda`."
+        )
+        warn(msg, FutureWarning, stacklevel=2)
+
         return _bivariate_handler(
             df,
             x,
@@ -1080,6 +1094,7 @@ class Moran_Rate(Moran):
         the relevant columns attached.
 
         """
+
         if not inplace:
             new = df.copy()
             cls.by_col(
@@ -1094,6 +1109,13 @@ class Moran_Rate(Moran):
                 **stat_kws,
             )
             return new
+
+        msg = (
+            "The `.by_col()` methods are deprecated and will be "
+            "removed in a future version of `esda`."
+        )
+        warn(msg, FutureWarning, stacklevel=2)
+
         if isinstance(events, str):
             events = [events]
         if isinstance(populations, str):
@@ -1466,6 +1488,13 @@ class Moran_Local:
         the relevant columns attached.
 
         """
+
+        msg = (
+            "The `.by_col()` methods are deprecated and will be "
+            "removed in a future version of `esda`."
+        )
+        warn(msg, FutureWarning, stacklevel=2)
+
         return _univariate_handler(
             df,
             cols,
@@ -1905,6 +1934,13 @@ class Moran_Local_BV:
         the relevant columns attached.
 
         """
+
+        msg = (
+            "The `.by_col()` methods are deprecated and will be "
+            "removed in a future version of `esda`."
+        )
+        warn(msg, FutureWarning, stacklevel=2)
+
         return _bivariate_handler(
             df,
             x,
@@ -2304,6 +2340,13 @@ class Moran_Local_Rate(Moran_Local):
                 **stat_kws,
             )
             return new
+
+        msg = (
+            "The `.by_col()` methods are deprecated and will be "
+            "removed in a future version of `esda`."
+        )
+        warn(msg, FutureWarning, stacklevel=2)
+
         if isinstance(events, str):
             events = [events]
         if isinstance(populations, str):


### PR DESCRIPTION
### mark `by_col()` methods as deprecated

see #305 

> the tests for the Moran*.by_col() methods have been deprecated and marked for removal "in the next release" (though that seems to have been [≈4 years ago](https://github.com/pysal/esda/blob/61b262faf43e9b3ecb157c9f8cc908414ef85524/esda/tests/test_moran.py#L49)), but is no actual indication the methods themselves are marked as such. For example, [Moran_Tester.test_by_col()](https://github.com/pysal/esda/blob/b8cc7c4c334f08f44a9cb2df46bac0f3faefa6b8/esda/tests/test_moran.py#L54-L55) is marked deprecated, but there is nothing mentioning that in [Moran.by_col()](https://github.com/pysal/esda/blob/b8cc7c4c334f08f44a9cb2df46bac0f3faefa6b8/esda/moran.py#L248)

----

* This first commit deprecates `by_col()` methods in `moran.py`
* Do we also need to start deprecating the `by_col()` methods in other modules & classes? -- xref https://github.com/pysal/esda/issues/305#issuecomment-4323054317
