### PR TITLE
remove deprecated 'by_col()' - `{gamma,geary}.py`

### DIFF
--- a/esda/gamma.py
+++ b/esda/gamma.py
@@ -6,7 +6,6 @@ Gamma index for spatial autocorrelation
 
 __author__ = "Luc Anselin <luc.anselin@asu.edu> Serge Rey <sjsrey@gmail.com>"
 
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -14,7 +13,6 @@ from libpysal.weights import W, lag_spatial
 
 from .crand import _prepare_univariate
 from .crand import njit as _njit
-from .tabular import _univariate_handler
 
 __all__ = ["Gamma"]
 
@@ -273,28 +271,6 @@ class Gamma:
         if psim > 0.5:
             psim = (self.permutations - larger + 1.0) / (self.permutations + 1.0)
         return psim
-
-    @classmethod
-    def by_col(
-        cls, df, cols, w=None, inplace=False, pvalue="sim", outvals=None, **stat_kws
-    ):
-        msg = (
-            "The `.by_col()` methods are deprecated and will be "
-            "removed in a future version of `esda`."
-        )
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-
-        return _univariate_handler(
-            df,
-            cols,
-            w=w,
-            inplace=inplace,
-            pvalue=pvalue,
-            outvals=outvals,
-            stat=cls,
-            swapname=cls.__name__.lower(),
-            **stat_kws,
-        )
 
 
 # --------------------------------------------------------------

--- a/esda/geary.py
+++ b/esda/geary.py
@@ -4,13 +4,10 @@ Geary's C statistic for spatial autocorrelation
 
 __author__ = "Serge Rey <sjsrey@gmail.com> "
 
-import warnings
 
 import numpy as np
 import scipy.stats as stats
 from libpysal import graph, weights
-
-from .tabular import _univariate_handler
 
 __all__ = ["Geary"]
 
@@ -190,63 +187,3 @@ class Geary:
         num = (self._weights * ((y[self._focal_ix] - y[self._neighbor_ix]) ** 2)).sum()
         a = (self.n - 1) * num
         return a / self.den
-
-    @classmethod
-    def by_col(
-        cls, df, cols, w=None, inplace=False, pvalue="sim", outvals=None, **stat_kws
-    ):
-        """
-        Function to compute a Geary statistic on a dataframe
-
-        Parameters
-        ----------
-        df : pandas.DataFrame
-            a pandas dataframe with a geometry column
-        cols : string or list of string
-            name or list of names of columns to use to compute the statistic
-        w : pysal weights object
-            a weights object aligned with the dataframe. If not provided, this
-            is searched for in the dataframe's metadata
-        inplace : bool
-            a boolean denoting whether to operate on the dataframe inplace or to
-            return a series contaning the results of the computation. If
-            operating inplace, with default configurations,
-            the derived columns will be named like 'column_geary' and 'column_p_sim'
-        pvalue  : string
-            a string denoting which pvalue should be returned. Refer to the
-            the Geary statistic's documentation for available p-values
-        outvals : list of strings
-            list of arbitrary attributes to return as columns from the
-            Geary statistic
-        **stat_kws : dict
-            options to pass to the underlying statistic. For this, see the
-            documentation for the Geary statistic.
-
-        Returns
-        --------
-        If inplace, None, and operation is conducted on dataframe in memory. Otherwise,
-        returns a copy of the dataframe with the relevant columns attached.
-
-        Notes
-        -----
-        Technical details and derivations can be found in :cite:`cliff81`.
-
-        """
-
-        msg = (
-            "The `.by_col()` methods are deprecated and will be "
-            "removed in a future version of `esda`."
-        )
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-
-        return _univariate_handler(
-            df,
-            cols,
-            w=w,
-            inplace=inplace,
-            pvalue=pvalue,
-            outvals=outvals,
-            stat=cls,
-            swapname=cls.__name__.lower(),
-            **stat_kws,
-        )

--- a/esda/tests/test_gamma.py
+++ b/esda/tests/test_gamma.py
@@ -80,24 +80,3 @@ class TestGamma:
         np.testing.assert_allclose(g4.g, 20.0)
         np.testing.assert_allclose(g4.g_z, 3.1879280354548638)
         np.testing.assert_allclose(g4.p_sim_g, 0.0030000000000000001)
-
-    @parametrize_lat
-    def test_by_col(self, w):
-        import pandas as pd
-
-        g = Gamma(self.y, w)
-
-        df = pd.DataFrame(self.y, columns=["y"])
-        r1 = Gamma.by_col(df, ["y"], w=w)
-        assert "y_gamma" in r1.columns
-        assert "y_p_sim" in r1.columns
-        this_gamma = np.unique(r1.y_gamma.values)
-        this_pval = np.unique(r1.y_p_sim.values)
-
-        np.testing.assert_allclose(this_gamma, g.g)
-        np.testing.assert_allclose(this_pval, g.p_sim)
-        Gamma.by_col(df, ["y"], inplace=True, operation="s", w=w)
-        this_gamma = np.unique(df.y_gamma.values)
-        this_pval = np.unique(df.y_p_sim.values)
-        np.testing.assert_allclose(this_gamma, 8.0)
-        np.testing.assert_allclose(this_pval, 0.001)

--- a/esda/tests/test_geary.py
+++ b/esda/tests/test_geary.py
@@ -59,16 +59,3 @@ class TestGeary:
         np.testing.assert_allclose(c.VC_sim, 0.010631247074115058)
         np.testing.assert_allclose(c.p_sim, 0.001)
         np.testing.assert_allclose(c.p_z_sim, 1.4207015378575605e-06)
-
-    @parametrize_w
-    def test_by_col(self, w):
-        import pandas as pd
-
-        df = pd.DataFrame(self.y, columns=["y"])
-        np.random.seed(12345)
-        r1 = geary.Geary.by_col(df, ["y"], w=w, permutations=999)
-        this_geary = np.unique(r1.y_geary.values)
-        this_pval = np.unique(r1.y_p_sim.values)
-        c = geary.Geary(self.y, w, permutations=999)
-        np.testing.assert_allclose(this_geary, c.C)
-        np.testing.assert_allclose(this_pval, c.p_sim)


### PR DESCRIPTION
continuing removal of deprecated 'by_col()' methods

* `gamma.py` - been deprecated for [4 years](https://github.com/pysal/esda/blame/main/esda/gamma.py#L281)
* `geary.py` - been deprecated for [4 years](https://github.com/pysal/esda/blame/main/esda/geary.py#L235)


------

xref #457 