### PR TITLE
remove deprecated 'by_col()' - `smoothing.py`

### DIFF
--- a/esda/smoothing.py
+++ b/esda/smoothing.py
@@ -18,19 +18,14 @@ __author__ = (
     "Serge Rey <srey@asu.edu"
 )
 
-import warnings
 from functools import reduce
 
 import numpy as np
 from libpysal.cg import (
     KDTree,
-    get_bounding_box,
 )
-from libpysal.common import requires as _requires
 from libpysal.weights.distance import Kernel
 from libpysal.weights.spatial_lag import lag_spatial as slag
-from libpysal.weights.util import get_points_array
-from libpysal.weights.weights import W
 from scipy.stats import chi2, gamma, norm, poisson
 
 __all__ = [
@@ -602,81 +597,7 @@ def assuncao_rate(e, b):
     return (y - ebi_b) / np.sqrt(ebi_v)
 
 
-class _Smoother:
-    """
-    This is a helper class that implements things that all smoothers should do.
-    Right now, the only thing that we need to propagate is the by_col function.
-
-    TBQH, most of these smoothers should be functions, not classes (aside from
-    maybe headbanging triples), since they're literally only inits + one
-    attribute.
-    """
-
-    def __init__(self):
-        pass
-
-    @classmethod
-    def by_col(cls, df, e, b, inplace=False, **kwargs):
-        """
-        Compute smoothing by columns in a dataframe.
-
-        Parameters
-        -----------
-        df      :  pandas.DataFrame
-                   a dataframe containing the data to be smoothed
-        e       :  string or list of strings
-                   the name or names of columns containing event variables to be
-                   smoothed
-        b       :  string or list of strings
-                   the name or names of columns containing the population
-                   variables to be smoothed
-        inplace :  bool
-                   a flag denoting whether to output a copy of `df` with the
-                   relevant smoothed columns appended, or to append the columns
-                   directly to `df` itself.
-        **kwargs:  optional keyword arguments
-                   optional keyword options that are passed directly to the
-                   smoother.
-
-        Returns
-        ---------
-        a copy of `df` containing the columns. Or, if `inplace`, this returns
-        None, but implicitly adds columns to `df`.
-        """
-
-        msg = (
-            "The `.by_col()` methods are deprecated and will be "
-            "removed in a future version of `esda`."
-        )
-        warnings.warn(msg, FutureWarning, stacklevel=True)
-
-        if not inplace:
-            new = df.copy()
-            cls.by_col(new, e, b, inplace=True, **kwargs)
-            return new
-        if isinstance(e, str):
-            e = [e]
-        if isinstance(b, str):
-            b = [b]
-        if len(b) == 1 and len(e) > 1:
-            b = b * len(e)
-        try:
-            assert len(e) == len(b)
-        except AssertionError:
-            raise ValueError(
-                "There is no one-to-one mapping between event "
-                "variable and population at risk variable!"
-            ) from None
-        for ei, bi in zip(e, b, strict=True):
-            ename = ei
-            bname = bi
-            ei = df[ename]
-            bi = df[bname]
-            outcol = "_".join(("-".join((ename, bname)), cls.__name__.lower()))
-            df[outcol] = cls(ei, bi, **kwargs).r
-
-
-class Excess_Risk(_Smoother):
+class Excess_Risk:
     """Excess Risk
 
     Parameters
@@ -732,7 +653,7 @@ class Excess_Risk(_Smoother):
         self.r = e * 1.0 / (b * r_mean)
 
 
-class Empirical_Bayes(_Smoother):
+class Empirical_Bayes:
     """Aspatial Empirical Bayes Smoothing
 
     Parameters
@@ -797,101 +718,7 @@ class Empirical_Bayes(_Smoother):
         self.r = weight * rate + (1.0 - weight) * r_mean
 
 
-class _Spatial_Smoother(_Smoother):
-    """
-    This is a helper class that implements things that all the things that
-    spatial smoothers should do.
-    .
-    Right now, the only thing that we need to propagate is the by_col function.
-
-    TBQH, most of these smoothers should be functions, not classes (aside from
-    maybe headbanging triples), since they're literally only inits + one
-    attribute.
-    """
-
-    def __init__(self):
-        pass
-
-    @classmethod
-    def by_col(cls, df, e, b, w=None, inplace=False, **kwargs):
-        """
-        Compute smoothing by columns in a dataframe.
-
-        Parameters
-        -----------
-        df      :  pandas.DataFrame
-                   a dataframe containing the data to be smoothed
-        e       :  string or list of strings
-                   the name or names of columns containing event variables to be
-                   smoothed
-        b       :  string or list of strings
-                   the name or names of columns containing the population
-                   variables to be smoothed
-        w       :  pysal.weights.W or list of pysal.weights.W
-                   the spatial weights object or objects to use with the
-                   event-population pairs. If not provided and a weights object
-                   is in the dataframe's metadata, that weights object will be
-                   used.
-        inplace :  bool
-                   a flag denoting whether to output a copy of `df` with the
-                   relevant smoothed columns appended, or to append the columns
-                   directly to `df` itself.
-        **kwargs:  optional keyword arguments
-                   optional keyword options that are passed directly to the
-                   smoother.
-
-        Returns
-        ---------
-        a copy of `df` containing the columns. Or, if `inplace`, this returns
-        None, but implicitly adds columns to `df`.
-        """
-
-        msg = (
-            "The `.by_col()` methods are deprecated and will be "
-            "removed in a future version of `esda`."
-        )
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-
-        if not inplace:
-            new = df.copy()
-            cls.by_col(new, e, b, w=w, inplace=True, **kwargs)
-            return new
-        if isinstance(e, str):
-            e = [e]
-        if isinstance(b, str):
-            b = [b]
-        if w is None:
-            found = False
-            for _ in df._metadata:
-                w = df.__dict__.get(w, None)
-                if isinstance(w, W):
-                    found = True
-            if not found:
-                raise ValueError(
-                    "Weights not provided and no weights attached to frame! "
-                    "Please provide a weight or attach a weight to the dataframe."
-                )
-        if isinstance(w, W):
-            w = [w] * len(e)
-        if len(b) == 1 and len(e) > 1:
-            b = b * len(e)
-        try:
-            assert len(e) == len(b)
-        except AssertionError:
-            raise ValueError(
-                "There is no one-to-one mapping between event "
-                "variable and population at risk variable!"
-            ) from None
-        for ei, bi, wi in zip(e, b, w, strict=True):
-            ename = ei
-            bname = bi
-            ei = df[ename]
-            bi = df[bname]
-            outcol = "_".join(("-".join((ename, bname)), cls.__name__.lower()))
-            df[outcol] = cls(ei, bi, w=wi, **kwargs).r
-
-
-class Spatial_Empirical_Bayes(_Spatial_Smoother):
+class Spatial_Empirical_Bayes:
     """Spatial Empirical Bayes Smoothing
 
     Parameters
@@ -979,7 +806,7 @@ class Spatial_Empirical_Bayes(_Spatial_Smoother):
         self.r = r_mean + (rate - r_mean) * (r_var / (r_var + (r_mean / b)))
 
 
-class Spatial_Rate(_Spatial_Smoother):
+class Spatial_Rate:
     """Spatial Rate Smoothing
 
     Parameters
@@ -1054,7 +881,7 @@ class Spatial_Rate(_Spatial_Smoother):
             w.transform = "o"
 
 
-class Kernel_Smoother(_Spatial_Smoother):
+class Kernel_Smoother:
     """Kernal smoothing
 
     Parameters
@@ -1124,7 +951,7 @@ class Kernel_Smoother(_Spatial_Smoother):
             self.r = w_e / w_b
 
 
-class Age_Adjusted_Smoother(_Spatial_Smoother):
+class Age_Adjusted_Smoother:
     """Age-adjusted rate smoothing
 
     Parameters
@@ -1207,104 +1034,8 @@ class Age_Adjusted_Smoother(_Spatial_Smoother):
         self.r = np.array([i[0] for i in r])
         w.transform = "o"
 
-    @_requires("pandas")
-    @classmethod
-    def by_col(cls, df, e, b, w=None, s=None, **kwargs):
-        """
-        Compute smoothing by columns in a dataframe.
 
-        Parameters
-        -----------
-        df      :  pandas.DataFrame
-                   a dataframe containing the data to be smoothed
-        e       :  string or list of strings
-                   the name or names of columns containing event variables to be
-                   smoothed
-        b       :  string or list of strings
-                   the name or names of columns containing the population
-                   variables to be smoothed
-        w       :  pysal.weights.W or list of pysal.weights.W
-                   the spatial weights object or objects to use with the
-                   event-population pairs. If not provided and a weights object
-                   is in the dataframe's metadata, that weights object will be
-                   used.
-        s       :  string or list of strings
-                   the name or names of columns to use as a standard population
-                   variable for the events `e` and at-risk populations `b`.
-        inplace :  bool
-                   a flag denoting whether to output a copy of `df` with the
-                   relevant smoothed columns appended, or to append the columns
-                   directly to `df` itself.
-        **kwargs:  optional keyword arguments
-                   optional keyword options that are passed directly to the
-                   smoother.
-
-        Returns
-        ---------
-        a copy of `df` containing the columns. Or, if `inplace`, this returns
-        None, but implicitly adds columns to `df`.
-        """
-
-        msg = (
-            "The `.by_col()` methods are deprecated and will be "
-            "removed in a future version of `esda`."
-        )
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-
-        if s is None:
-            raise ValueError("Standard population variable 's' must be supplied.")
-        import pandas as pd
-
-        if isinstance(e, str):
-            e = [e]
-        if isinstance(b, str):
-            b = [b]
-        if isinstance(s, str):
-            s = [s]
-        if w is None:
-            found = False
-            for _ in df._metadata:
-                w = df.__dict__.get(w, None)
-                if isinstance(w, W):
-                    found = True
-                    break
-            if not found:
-                raise ValueError(
-                    "Weights not provided and no weights attached to frame!"
-                    " Please provide a weight or attach a weight to the dataframe."
-                )
-        if isinstance(w, W):
-            w = [w] * len(e)
-        if not all(isinstance(wi, W) for wi in w):
-            raise TypeError("Weights object must be an instance of libpysal.weights.W!")
-        b = b * len(e) if len(b) == 1 and len(e) > 1 else b
-        s = s * len(e) if len(s) == 1 and len(e) > 1 else s
-        try:
-            assert len(e) == len(b)
-            assert len(e) == len(s)
-            assert len(e) == len(w)
-        except AssertionError:
-            raise ValueError(
-                "There is no one-to-one mapping between event variable and "
-                "population variable and population at risk variable, and "
-                " standard population variable, and spatial weights!"
-            ) from None
-        rdf = []
-        max_len = 0
-        for ei, bi, wi, si in zip(e, b, w, s, strict=True):
-            ename = ei
-            bname = bi
-            outcol = "_".join(("-".join((ename, bname)), cls.__name__.lower()))
-            this_r = cls(df[ei], df[bi], w=wi, s=df[si], **kwargs).r
-            max_len = 0 if len(this_r) > max_len else max_len
-            rdf.append((outcol, this_r.tolist()))
-        padded = (r[1] + [None] * max_len for r in rdf)
-        rdf = dict(zip((r[0] for r in rdf), padded, strict=True))
-        rdf = pd.DataFrame.from_dict(rdf)
-        return rdf
-
-
-class Disk_Smoother(_Spatial_Smoother):
+class Disk_Smoother:
     """Locally weighted averages or disk smoothing
 
     Parameters
@@ -1381,7 +1112,7 @@ class Disk_Smoother(_Spatial_Smoother):
             self.r = slag(w, r) / np.array(weight_sum).reshape(-1, 1)
 
 
-class Spatial_Median_Rate(_Spatial_Smoother):
+class Spatial_Median_Rate:
     """Spatial Median Rate Smoothing
 
     Parameters
@@ -1509,7 +1240,7 @@ class Spatial_Median_Rate(_Spatial_Smoother):
         self.r = np.asarray(new_r).reshape(r.shape)
 
 
-class Spatial_Filtering(_Smoother):
+class Spatial_Filtering:
     """Spatial Filtering
 
     Parameters
@@ -1635,71 +1366,3 @@ class Spatial_Filtering(_Smoother):
                     b_n_f = b_n[[0]]
                 self.r.append(e_n_f[-1] * 1.0 / b_n_f[-1])
         self.r = np.array(self.r)
-
-    @_requires("pandas")
-    @classmethod
-    def by_col(cls, df, e, b, x_grid, y_grid, geom_col="geometry", **kwargs):
-        """
-        Compute smoothing by columns in a dataframe. The bounding box and point
-        information is computed from the geometry column.
-
-        Parameters
-        -----------
-        df      :  pandas.DataFrame
-                   a dataframe containing the data to be smoothed
-        e       :  string or list of strings
-                   the name or names of columns containing event variables to be
-                   smoothed
-        b       :  string or list of strings
-                   the name or names of columns containing the population
-                   variables to be smoothed
-        x_grid  :  integer
-                   number of grid cells to use along the x-axis
-        y_grid  :  integer
-                   number of grid cells to use along the y-axis
-        geom_col:  string
-                   the name of the column in the dataframe containing the
-                   geometry information.
-        **kwargs:  optional keyword arguments
-                   optional keyword options that are passed directly to the
-                   smoother.
-        Returns
-        ---------
-        a new dataframe of dimension (x_grid*y_grid, 3), containing the
-        coordinates of the grid cells and the rates associated with those grid
-        cells.
-        """
-
-        msg = (
-            "The `.by_col()` methods are deprecated and will be "
-            "removed in a future version of `esda`."
-        )
-        warnings.warn(msg, FutureWarning, stacklevel=2)
-
-        import pandas as pd
-
-        # prep for application over multiple event/population pairs
-        if isinstance(e, str):
-            e = [e]
-        if isinstance(b, str):
-            b = [b]
-        if len(e) > len(b):
-            b = b * len(e)
-        if isinstance(x_grid, int | float):
-            x_grid = [x_grid] * len(e)
-        if isinstance(y_grid, int | float):
-            y_grid = [y_grid] * len(e)
-
-        bbox = get_bounding_box(df[geom_col])
-        bbox = [[bbox.left, bbox.lower], [bbox.right, bbox.upper]]
-        data = get_points_array(df[geom_col])
-        res = []
-        for ename, bname, xgi, ygi in zip(e, b, x_grid, y_grid, strict=True):
-            r = cls(bbox, data, df[ename], df[bname], xgi, ygi, **kwargs)
-            grid = np.asarray(r.grid).reshape(-1, 2)
-            name = "_".join(("-".join((ename, bname)), cls.__name__.lower()))
-            colnames = ("_".join((name, suffix)) for suffix in ["X", "Y", "R"])
-            items = list(zip(colnames, [grid[:, 0], grid[:, 1], r.r], strict=True))
-            res.append(pd.DataFrame.from_dict(dict(items)))
-        outdf = pd.concat(res)
-        return outdf

--- a/esda/tests/test_smaup.py
+++ b/esda/tests/test_smaup.py
@@ -1,3 +1,5 @@
+import re
+
 import libpysal
 import numpy as np
 import pytest
@@ -51,7 +53,14 @@ class TestSmaup:
         df = pdio.read_files(libpysal.examples.get_path("sids2.dbf"))
         w = libpysal.io.open(libpysal.examples.get_path("sids2.gal")).read()
         k = int(w.n / 2)
-        mi = Moran.by_col(df, ["SIDR74"], w=w, two_tailed=False)
+        with pytest.warns(
+            FutureWarning,
+            match=re.escape(
+                "The `.by_col()` methods are deprecated and will be "
+                "removed in a future version of `esda`."
+            ),
+        ):
+            mi = Moran.by_col(df, ["SIDR74"], w=w, two_tailed=False)
         rho = np.unique(mi.SIDR74_moran.values).item()
         sm = Smaup(w.n, k, rho)
         np.testing.assert_allclose(sm.smaup, 0.15176796553181948, atol=ATOL, rtol=RTOL)

--- a/esda/tests/test_smoothing.py
+++ b/esda/tests/test_smoothing.py
@@ -117,11 +117,6 @@ class TestSRate:
         out_er = sm.Excess_Risk(self.df[self.ename], self.df[self.bname]).r
         np.testing.assert_allclose(out_er[:5].flatten(), self.er, rtol=RTOL, atol=ATOL)
         assert isinstance(out_er, np.ndarray)
-        out_er = sm.Excess_Risk.by_col(self.df, self.ename, self.bname)
-        outcol = f"{self.ename}-{self.bname}_excess_risk"
-        outcol = out_er[outcol]
-        np.testing.assert_allclose(outcol[:5], self.er, rtol=RTOL, atol=ATOL)
-        assert isinstance(outcol.values, np.ndarray)
 
     def test_empirical_bayes(self):
         out_eb = sm.Empirical_Bayes(self.e, self.b).r
@@ -132,12 +127,6 @@ class TestSRate:
         out_eb = sm.Empirical_Bayes(self.df[self.ename], self.df[self.bname]).r
         np.testing.assert_allclose(out_eb[:5].flatten(), self.eb, rtol=RTOL, atol=ATOL)
         assert isinstance(out_eb, np.ndarray)
-
-        out_eb = sm.Empirical_Bayes.by_col(self.df, self.ename, self.bname)
-        outcol = f"{self.ename}-{self.bname}_empirical_bayes"
-        outcol = out_eb[outcol]
-        np.testing.assert_allclose(outcol[:5], self.eb, rtol=RTOL, atol=ATOL)
-        assert isinstance(outcol.values, np.ndarray)
 
     def test_spatial_empirical_bayes(self):
         s_eb = sm.Spatial_Empirical_Bayes(self.stl_e, self.stl_b, self.stl_w)
@@ -151,14 +140,6 @@ class TestSRate:
         assert isinstance(s_eb, np.ndarray)
         np.testing.assert_allclose(self.s_ebr10, s_eb[:10])
 
-        s_eb = sm.Spatial_Empirical_Bayes.by_col(
-            self.stl_df, self.stl_ename, self.stl_bname, self.stl_w
-        )
-        outcol = f"{self.stl_ename}-{self.stl_bname}_spatial_empirical_bayes"
-        r = s_eb[outcol].values
-        assert isinstance(r, np.ndarray)
-        np.testing.assert_allclose(self.s_ebr10, r[:10].reshape(-1, 1))
-
     def test_spatial_rate(self):
         out_sr = sm.Spatial_Rate(self.e, self.b, self.w).r
         np.testing.assert_allclose(out_sr[:5].flatten(), self.sr, rtol=RTOL, atol=ATOL)
@@ -168,12 +149,6 @@ class TestSRate:
         out_sr = sm.Spatial_Rate(self.df[self.ename], self.df[self.bname], self.w).r
         np.testing.assert_allclose(out_sr[:5].flatten(), self.sr, rtol=RTOL, atol=ATOL)
         assert isinstance(out_sr, np.ndarray)
-
-        out_sr = sm.Spatial_Rate.by_col(self.df, self.ename, self.bname, w=self.w)
-        outcol = f"{self.ename}-{self.bname}_spatial_rate"
-        r = out_sr[outcol].values
-        assert isinstance(r, np.ndarray)
-        np.testing.assert_allclose(r[:5], self.sr, rtol=RTOL, atol=ATOL)
 
     def test_spatial_median_rate(self):
         out_smr = sm.Spatial_Median_Rate(self.e, self.b, self.w).r
@@ -214,56 +189,6 @@ class TestSRate:
         np.testing.assert_allclose(
             out_smr2[:5].flatten(), self.smr2, atol=ATOL, rtol=RTOL
         )
-
-        out_smr = sm.Spatial_Median_Rate.by_col(self.df, self.ename, self.bname, self.w)
-        out_smr_w = sm.Spatial_Median_Rate.by_col(
-            self.df, self.ename, self.bname, self.w, aw=self.df[self.bname]
-        )
-        out_smr2 = sm.Spatial_Median_Rate.by_col(
-            self.df, self.ename, self.bname, self.w, iteration=2
-        )
-        outcol = f"{self.ename}-{self.bname}_spatial_median_rate"
-
-        np.testing.assert_allclose(
-            out_smr[outcol].values[:5], self.smr, rtol=RTOL, atol=ATOL
-        )
-        np.testing.assert_allclose(
-            out_smr_w[outcol].values[:5], self.smr_w, rtol=RTOL, atol=ATOL
-        )
-        np.testing.assert_allclose(
-            out_smr2[outcol].values[:5], self.smr2, rtol=RTOL, atol=ATOL
-        )
-
-    @pytest.mark.skipif(PANDAS_EXTINCT, reason="missing pandas")
-    def test_Spatial_Smoother_multicol(self):
-        # test that specifying multiple columns works correctly. Since the
-        # function is shared over all spatial smoothers, we can only test one.
-        enames = [self.ename, "SID79"]
-        bnames = [self.bname, "BIR79"]
-        out_df = sm.Spatial_Median_Rate.by_col(self.df, enames, bnames, self.w)
-        outcols = [
-            f"{e}-{b}_spatial_median_rate" for e, b in zip(enames, bnames, strict=True)
-        ]
-        smr79 = np.array([0.00122129, 0.00176924, 0.00176924, 0.00240964, 0.00272035])
-        answers = [self.smr, smr79]
-        for col, answer in zip(outcols, answers, strict=True):
-            np.testing.assert_allclose(
-                out_df[col].values[:5], answer, rtol=1e-4, atol=1e-6
-            )
-
-    @pytest.mark.skipif(PANDAS_EXTINCT, reason="missing pandas")
-    def test_Smoother_multicol(self):
-        # test that non-spatial smoothers work with multicolumn queries
-        enames = [self.ename, "SID79"]
-        bnames = [self.bname, "BIR79"]
-        out_df = sm.Excess_Risk.by_col(self.df, enames, bnames)
-        outcols = [f"{e}-{b}_excess_risk" for e, b in zip(enames, bnames, strict=True)]
-        er79 = np.array([0.000000, 2.796607, 0.8383863, 1.217479, 0.943811])
-        answers = [self.er, er79]
-        for col, answer in zip(outcols, answers, strict=True):
-            np.testing.assert_allclose(
-                out_df[col].values[:5], answer, rtol=1e-4, atol=1e-7
-            )
 
 
 class TestKernelAgeAdjSM:
@@ -330,13 +255,6 @@ class TestKernelAgeAdjSM:
         assert isinstance(kr.r, np.ndarray)
         np.testing.assert_allclose(kr.r, self.ageadj_exp)
 
-        kr = sm.Age_Adjusted_Smoother.by_col(dfb, "e", "b", w=self.kw, s="s")
-        answer = np.array(
-            [0.10519625, 0.08494318, 0.06440072, 0.06898604, 0.06952076, 0.05020968]
-        )
-        colname = "e-b_age_adjusted_smoother"
-        np.testing.assert_allclose(kr[colname].values, answer, rtol=RTOL, atol=ATOL)
-
     def test_disk_smoother(self):
         self.kw.transform = "b"
         disk = sm.Disk_Smoother(self.e, self.b, self.kw)
@@ -348,12 +266,6 @@ class TestKernelAgeAdjSM:
         dfa = self.dfa
         disk = sm.Disk_Smoother(dfa.e, dfa.b, self.kw).r
         np.testing.assert_allclose(disk.flatten(), self.disk_exp)
-
-        disk = sm.Disk_Smoother.by_col(dfa, "e", "b", self.kw)
-        col = "e-b_disk_smoother"
-        np.testing.assert_allclose(
-            disk[col].values, self.disk_exp, rtol=RTOL, atol=ATOL
-        )
 
     def test_spatial_filtering(self):
         points = np.array(self.points)
@@ -369,40 +281,6 @@ class TestKernelAgeAdjSM:
         sf = sm.Spatial_Filtering(bbox, point_array, dfa.e, dfa.b, 2, 2, r=30)
 
         np.testing.assert_allclose(sf.r, self.sf_exp, rtol=RTOL, atol=ATOL)
-
-        dfa["geometry"] = self.points
-        sf = sm.Spatial_Filtering.by_col(dfa, "e", "b", 3, 3, r=30)
-        r_answer = np.array(
-            [
-                0.07692308,
-                0.07213115,
-                0.07213115,
-                0.07692308,
-                0.07692308,
-                0.07692308,
-                0.07692308,
-                0.07692308,
-                0.07692308,
-            ]
-        )
-        x_answer = np.array([10.0, 10.0, 10.0, 20.0, 20.0, 20.0, 30.0, 30.0, 30.0])
-        y_answer = np.array(
-            [
-                10.000000,
-                16.666667,
-                23.333333,
-                10.000000,
-                16.666667,
-                23.333333,
-                10.000000,
-                16.666667,
-                23.333333,
-            ]
-        )
-        columns = [f"e-b_spatial_filtering_{name}" for name in ["X", "Y", "R"]]
-
-        for col, answer in zip(columns, [x_answer, y_answer, r_answer], strict=True):
-            np.testing.assert_allclose(sf[col].values, answer, rtol=RTOL, atol=ATOL)
 
 
 class TestUtils:


### PR DESCRIPTION
* remove deprecated 'by_col()' - `smoothing.py`
  * https://github.com/pysal/esda/blame/1545eae8a0b6818e5fc213f94c996d28b5cfba61/esda/smoothing.py#L646
  * https://github.com/pysal/esda/blame/1545eae8a0b6818e5fc213f94c996d28b5cfba61/esda/smoothing.py#L848
* also entirely removes the private [`_Smoother()`](https://github.com/pysal/esda/blob/1545eae8a0b6818e5fc213f94c996d28b5cfba61/esda/smoothing.py#L605) and [`_Spatial_Smoother()`](https://github.com/pysal/esda/blob/1545eae8a0b6818e5fc213f94c996d28b5cfba61/esda/smoothing.py#L800) classes that only existed to implement the `.by_col()` method
* xref #462 