### PR TITLE
clean up some warnings in CI – [2026-05-01]

### DIFF
--- a/esda/correlogram.py
+++ b/esda/correlogram.py
@@ -6,7 +6,6 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
-from libpysal.cg.kdtree import KDTree
 from libpysal.weights import KNN, DistanceBand
 from libpysal.weights.util import get_points_array
 from scipy import linalg, spatial
@@ -145,7 +144,7 @@ def correlogram(
             "geometry must be of type Point. Try sending geometry.centroid"
         )
 
-    tree = KDTree(get_points_array(geometry.values))
+    tree = spatial.KDTree(get_points_array(geometry.values))
 
     if support is None:
         if distance_type == "band":

--- a/esda/smoothing.py
+++ b/esda/smoothing.py
@@ -21,11 +21,9 @@ __author__ = (
 from functools import reduce
 
 import numpy as np
-from libpysal.cg import (
-    KDTree,
-)
 from libpysal.weights.distance import Kernel
 from libpysal.weights.spatial_lag import lag_spatial as slag
+from scipy.spatial import KDTree
 from scipy.stats import chi2, gamma, norm, poisson
 
 __all__ = [

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -120,6 +120,7 @@ class TestMoran:
     @parametrize_sac
     def test_plot_simulation(self, w):
         pytest.importorskip("seaborn")
+        plt = pytest.importorskip("matplotlib.pyplot")
 
         m = moran.Moran(sac1.WHITE, w=w)
         ax = m.plot_simulation()
@@ -155,6 +156,8 @@ class TestMoran:
             ei_vline.get_paths()[0].vertices,
             np.array([[m.EI, 0.0], [m.EI, 1.0]]),
         )
+
+        plt.close()
 
     @parametrize_sac
     def test_plot_simulation_custom(self, w):
@@ -206,8 +209,12 @@ class TestMoran:
             "Expected I",
         ]
 
+        plt.close()
+
     @parametrize_sac
     def test_plot_scatter(self, w):
+        plt = pytest.importorskip("matplotlib.pyplot")
+
         import matplotlib
 
         matplotlib.use("Agg")
@@ -234,8 +241,11 @@ class TestMoran:
         np.testing.assert_almost_equal(y.max(), 1.634939204358587)
         assert l_.get_color() == "#d6604d"
 
+        plt.close()
+
     @parametrize_sac
     def test_plot_scatter_args(self, w):
+        plt = pytest.importorskip("matplotlib.pyplot")
         import matplotlib
 
         matplotlib.use("Agg")
@@ -258,6 +268,8 @@ class TestMoran:
         # test fitline
         l_ = ax.lines[2]
         assert l_.get_color() == "pink"
+
+        plt.close()
 
 
 class TestMoranRate:
@@ -302,6 +314,8 @@ class TestMoranBVmatrix:
 
     @parametrize_sids
     def test_plot_moran_facet(self, w):
+        plt = pytest.importorskip("matplotlib.pyplot")
+
         matrix = moran.Moran_BV_matrix(self.vars_, w, varnames=self.names)
         axes = moran.plot_moran_facet(matrix)
         assert axes.shape == (4, 4)
@@ -319,6 +333,8 @@ class TestMoranBVmatrix:
             axes[1][1].get_facecolor(),
             (0.8509803921568627, 0.8509803921568627, 0.8509803921568627, 1.0),
         )
+
+        plt.close()
 
 
 class TestMoranLocal:
@@ -402,6 +418,7 @@ class TestMoranLocal:
 
     @parametrize_sac
     def test_plot(self, w):
+        plt = pytest.importorskip("matplotlib.pyplot")
         import matplotlib
 
         matplotlib.use("Agg")
@@ -447,8 +464,11 @@ class TestMoranLocal:
 
             np.testing.assert_array_equal(counts, np.array([86, 3, 298, 38, 3]))
 
+        plt.close()
+
     @parametrize_sac
     def test_plot_scatter(self, w):
+        plt = pytest.importorskip("matplotlib.pyplot")
         import matplotlib
 
         matplotlib.use("Agg")
@@ -491,8 +511,11 @@ class TestMoranLocal:
         np.testing.assert_almost_equal(y.max(), 1.634939204358587)
         assert l_.get_color() == "k"
 
+        plt.close()
+
     @parametrize_sac
     def test_plot_scatter_args(self, w):
+        plt = pytest.importorskip("matplotlib.pyplot")
         import matplotlib
 
         matplotlib.use("Agg")
@@ -522,6 +545,8 @@ class TestMoranLocal:
         l_ = ax.lines[2]
         assert l_.get_color() == "#d6604d"
         assert l_.get_linewidth() == 4.0
+
+        plt.close()
 
     @parametrize_desmith
     def test_parallel(self, w):
@@ -624,6 +649,7 @@ class TestMoranLocal:
 
     @parametrize_sac
     def test_plot_combination(self, w):
+        plt = pytest.importorskip("matplotlib.pyplot")
         import matplotlib
 
         matplotlib.use("Agg")
@@ -670,6 +696,8 @@ class TestMoranLocal:
         else:
             assert len(axs2[1].collections) == 1
             assert len(axs2[2].collections) == 1
+
+        plt.close()
 
 
 class TestMoranLocalBV:
@@ -785,6 +813,7 @@ class TestMoranLocalBV:
 
     @parametrize_sids
     def test_plot(self, w):
+        plt = pytest.importorskip("matplotlib.pyplot")
         import matplotlib
 
         matplotlib.use("Agg")
@@ -829,9 +858,11 @@ class TestMoranLocalBV:
                 ),
             )
             np.testing.assert_array_equal(counts, np.array([6, 2, 86, 7, 7]))
+        plt.close()
 
     @parametrize_sids
     def test_plot_combination(self, w):
+        plt = pytest.importorskip("matplotlib.pyplot")
         import matplotlib
 
         matplotlib.use("Agg")
@@ -860,6 +891,7 @@ class TestMoranLocalBV:
         else:
             assert len(axs[1].collections) == 3
             assert len(axs[2].collections) == 3
+        plt.close()
 
 
 class TestMoranLocalRate:

--- a/esda/tests/test_topo.py
+++ b/esda/tests/test_topo.py
@@ -1,7 +1,6 @@
 import importlib
 
 import geopandas
-import matplotlib.pyplot as plt
 import numpy
 import pandas
 import pytest
@@ -135,6 +134,7 @@ class TestTopo:
 @image_comparison(["topo4x1"], extensions=["png"], tol=1.0)
 def test_plots():
     pytest.importorskip("rtree")
+    plt = pytest.importorskip("matplotlib.pyplot")
 
     current_cmap = plt.get_cmap("twilight")
     current_cmap.set_bad(color="lightgrey")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,4 +126,5 @@ filterwarnings = [
     "ignore:Geometry is in a geographic CRS",
     "ignore:divide by zero encountered",
     "ignore:invalid value encountered",
+    "ignore:Numba not imported, so alpha shape construction may be slower",
 ]


### PR DESCRIPTION
## clean warnings in CI – [2026-05-01]

* KDTree warning from `libpysal` dev
  * https://github.com/pysal/esda/actions/runs/25238317593/job/74009669234#step:6:495

```
FutureWarning: The KDTree class is deprecated and will be removed in a future version of libpysal. Use ``scipy.spatial.KDTree`` directly.
    tree = KDTree(get_points_array(geometry.values))
```

* Numba warning from `libpysal`
  * https://github.com/pysal/esda/actions/runs/25238317593/job/74009669234#step:6:487

```
UserWarning: Numba not imported, so alpha shape construction may be slower than expected.
    return alpha_shape_auto(coordinates)
```

* Matplotlib warnings -- too many figures open
  * https://github.com/pysal/esda/actions/runs/25238317593/job/74009669343#step:6:458

```
RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`). Consider using `matplotlib.pyplot.close()`.
    fig, ax = plt.subplots(figsize=figsize)
``` 