### PR TITLE
Handle more CI warnings CI – [2026-05-02]

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,12 +3,12 @@
  on:
    push:
      branches:
-     - '*'
+     - "*"
    pull_request:
      branches:
-     - '*'
+     - "*"
    schedule:
-     - cron: '59 21 * * *'
+     - cron: "59 21 * * *"
    workflow_dispatch:
      inputs:
        version:
@@ -19,8 +19,10 @@
  jobs:
    unittests:
      env:
-       FETCH_DATA: python -c 'from libpysal.examples import load_example as ex; [ex(e) for e in ["columbus", "desmith", "NCOVR", "sids2", "stl", "Sacramento1"]]'
-       RUN_TEST: pytest esda -v -r a -n auto --cov esda --cov-report xml --color yes --cov-append --cov-report term-missing
+       FETCH_DATA: |
+         python -c 'from libpysal.examples import load_example as ex; [ex(e) for e in ["columbus", "desmith", "NCOVR", "sids2", "stl", "Sacramento1"]]'
+       RUN_TEST: |
+         pytest esda -v -r a -n auto --cov esda --cov-report xml --color yes --cov-append --cov-report term-missing
      name: CI (${{ matrix.os }}, ${{ matrix.environment-file }})
      runs-on: ${{ matrix.os }}
      timeout-minutes: 25
@@ -55,10 +57,13 @@
      steps:
        - name: checkout repo
          uses: actions/checkout@v6
+         with:
+          fetch-depth: 0 # Fetch all history for all branches and tags.
+
        - name: setup micromamba
          uses: mamba-org/setup-micromamba@v3
          with:
-            micromamba-version: 'latest'
+            micromamba-version: "latest"
             environment-file: ${{ matrix.environment-file }}
 
        - name: environment info
@@ -66,8 +71,13 @@
            micromamba info
            micromamba list
 
+      - name: install package
+        run: |
+          pip install -e . --no-deps
+
        - name: spatial versions
-         run: 'python -c "import geopandas; geopandas.show_versions();"'
+         run: |
+           python -c "import geopandas; geopandas.show_versions();"
 
        - name: run tests - bash
          run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -58,22 +58,22 @@
        - name: checkout repo
          uses: actions/checkout@v6
          with:
-          fetch-depth: 0 # Fetch all history for all branches and tags.
+           fetch-depth: 0 # Fetch all history for all branches and tags.
 
        - name: setup micromamba
          uses: mamba-org/setup-micromamba@v3
          with:
-            micromamba-version: "latest"
-            environment-file: ${{ matrix.environment-file }}
+           micromamba-version: "latest"
+           environment-file: ${{ matrix.environment-file }}
 
        - name: environment info
          run: |
            micromamba info
            micromamba list
 
-      - name: install package
-        run: |
-          pip install -e . --no-deps
+       - name: install package
+         run: |
+           pip install -e . --no-deps
 
        - name: spatial versions
          run: |

--- a/esda/crand.py
+++ b/esda/crand.py
@@ -563,7 +563,7 @@ def parallel_crand(
 
     p_sims, rlocals = zip(*worker_out, strict=True)
     p_sims = np.hstack(p_sims).squeeze()
-    rlocals = np.row_stack(rlocals).squeeze()
+    rlocals = np.vstack(rlocals).squeeze()
     return p_sims, rlocals
 
 

--- a/esda/moran_local_mv.py
+++ b/esda/moran_local_mv.py
@@ -191,8 +191,8 @@ class MoranLocalPartial:
             quads = negative_lag.astype(int).flatten() * 2 + off_sign.astype(int) + 1
             uvquads.append(quads.flatten())
 
-        self._uvquads_ = np.row_stack(uvquads).T
-        self._mvquads_ = np.row_stack(component_quads).T
+        self._uvquads_ = np.vstack(uvquads).T
+        self._mvquads_ = np.vstack(component_quads).T
         return self
 
     def _make_data(self, z, X, W):

--- a/esda/tests/conftest.py
+++ b/esda/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+def pytest_configure(config):  # noqa: ARG001
+
+    pytest.WARN_ALT_HYPOTHESIS_DEPR = pytest.warns(
+        DeprecationWarning,
+        match=(
+            "The alternative hypothesis for conditional randomization "
+            "is changing in the next major release of esda."
+        ),
+    )

--- a/esda/tests/test_getisord.py
+++ b/esda/tests/test_getisord.py
@@ -86,8 +86,14 @@ class TestGLocal:
             getisord.G_Local(self.y, w, transform="R", star=True, seed=10)
 
     @parametrize_w
+    @pytest.mark.xfail(
+        reason="Intermittently does not warn for W param; reason unknown; see gh#331"
+    )
     def test_star_row_standardized_values(self, w):
-        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+        with (
+            pytest.WARN_ALT_HYPOTHESIS_DEPR,
+            pytest.warns(UserWarning, match="Gi\\* requested, but"),
+        ):
             lg = getisord.G_Local(self.y, w, transform="R", star=True, seed=10)
         np.testing.assert_allclose(lg.Zs[0], -0.62488094, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(lg.p_sim[0], 0.102, rtol=RTOL, atol=ATOL)

--- a/esda/tests/test_getisord.py
+++ b/esda/tests/test_getisord.py
@@ -25,7 +25,8 @@ def test_g_local_legacy_crand_deprecated():
     w = DistanceBand(points, threshold=15)
     y = np.array([2, 3, 3.2, 5, 8, 7])
 
-    gl = getisord.G_Local(y, w, transform="B", permutations=99)
+    with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+        gl = getisord.G_Local(y, w, transform="B", permutations=99)
 
     with pytest.warns(
         DeprecationWarning,
@@ -53,20 +54,23 @@ class TestGLocal:
 
     @parametrize_w
     def test_binary(self, w):
-        lg = getisord.G_Local(self.y, w, transform="B", seed=10)
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lg = getisord.G_Local(self.y, w, transform="B", seed=10)
         np.testing.assert_allclose(lg.Zs[0], -1.0136729, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(lg.p_sim[0], 0.102, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(lg.p_z_sim[0], 0.153923, rtol=RTOL, atol=ATOL)
 
     @parametrize_w
     def test_row_standardized(self, w):
-        lg = getisord.G_Local(self.y, w, transform="R", seed=10)
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lg = getisord.G_Local(self.y, w, transform="R", seed=10)
         np.testing.assert_allclose(lg.Zs[0], -0.62074534, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(lg.p_sim[0], 0.102, rtol=RTOL, atol=ATOL)
 
     @parametrize_w
     def test_star_binary(self, w):
-        lg = getisord.G_Local(self.y, w, transform="B", star=True, seed=10)
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lg = getisord.G_Local(self.y, w, transform="B", star=True, seed=10)
         np.testing.assert_allclose(lg.Zs[0], -1.39727626, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(lg.p_sim[0], 0.102, rtol=RTOL, atol=ATOL)
 
@@ -75,11 +79,15 @@ class TestGLocal:
         reason="Intermittently does not warn for W param; reason unknown; see gh#331"
     )
     def test_star_row_standardized_warning(self, w):
-        with pytest.warns(UserWarning, match="Gi\\* requested, but"):
+        with (
+            pytest.WARN_ALT_HYPOTHESIS_DEPR,
+            pytest.warns(UserWarning, match="Gi\\* requested, but"),
+        ):
             getisord.G_Local(self.y, w, transform="R", star=True, seed=10)
 
     @parametrize_w
     def test_star_row_standardized_values(self, w):
-        lg = getisord.G_Local(self.y, w, transform="R", star=True, seed=10)
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lg = getisord.G_Local(self.y, w, transform="R", star=True, seed=10)
         np.testing.assert_allclose(lg.Zs[0], -0.62488094, rtol=RTOL, atol=ATOL)
         np.testing.assert_allclose(lg.p_sim[0], 0.102, rtol=RTOL, atol=ATOL)

--- a/esda/tests/test_ljc.py
+++ b/esda/tests/test_ljc.py
@@ -26,5 +26,6 @@ class TestJoinCountsLocal:
     @parametrize_w
     def test_defaults(self, w):
         np.random.seed(12345)
-        ljc = Join_Counts_Local(connectivity=w).fit(self.y)
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            ljc = Join_Counts_Local(connectivity=w).fit(self.y)
         assert np.array_equal(ljc.LJC, [0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 3, 2, 2, 3, 3, 2])

--- a/esda/tests/test_ljc_bv.py
+++ b/esda/tests/test_ljc_bv.py
@@ -27,9 +27,10 @@ class TestLocalJoinCountsBV:
     @parametrize_w
     def test_bjc(self, w):
         np.random.seed(12345)
-        ljc_bv_case1 = Join_Counts_Local_BV(connectivity=w).fit(
-            self.x, self.z, case="BJC"
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            ljc_bv_case1 = Join_Counts_Local_BV(connectivity=w).fit(
+                self.x, self.z, case="BJC"
+            )
         assert np.array_equal(
             ljc_bv_case1.LJC, [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0]
         )
@@ -37,9 +38,10 @@ class TestLocalJoinCountsBV:
     @parametrize_w
     def test_clc(self, w):
         np.random.seed(12345)
-        ljc_bv_case2 = Join_Counts_Local_BV(connectivity=w).fit(
-            self.x, self.z, case="CLC"
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            ljc_bv_case2 = Join_Counts_Local_BV(connectivity=w).fit(
+                self.x, self.z, case="CLC"
+            )
         assert np.array_equal(
             ljc_bv_case2.LJC, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 2, 2]
         )

--- a/esda/tests/test_ljc_mv.py
+++ b/esda/tests/test_ljc_mv.py
@@ -28,7 +28,8 @@ class TestLocalJoinCountsMV:
     @parametrize_w
     def test_defaults(self, w):
         np.random.seed(12345)
-        ljc_mv = Join_Counts_Local_MV(connectivity=w).fit([self.x, self.y, self.z])
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            ljc_mv = Join_Counts_Local_MV(connectivity=w).fit([self.x, self.y, self.z])
         assert np.array_equal(
             ljc_mv.LJC, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 2]
         )

--- a/esda/tests/test_local_geary.py
+++ b/esda/tests/test_local_geary.py
@@ -24,6 +24,7 @@ class TestGearyLocal:
 
     @parametrize_w
     def test_defaults(self, w):
-        lG = Geary_Local(connectivity=w).fit(self.y)
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lG = Geary_Local(connectivity=w).fit(self.y)
         np.testing.assert_allclose(lG.localG[0], 0.696703432)
         np.testing.assert_allclose(lG.p_sim[0], 0.19)

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -14,6 +14,7 @@ GPD_GE_120 = (Version(gpd.__version__) >= Version("1.1.2.dev")) and Version(
     gpd.__version__
 ).is_devrelease
 
+
 parametrize_stl = pytest.mark.parametrize(
     "w",
     [
@@ -101,7 +102,8 @@ class TestMoran:
     def test_z_consistency(self, w):
         m1 = moran.Moran(self.y, w)
         # m2 = moran.Moran_BV(self.x, self.y, self.w) TODO testing for other.z values
-        m3 = moran.Moran_Local(self.y, w, keep_simulations=True, seed=SEED)
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            m3 = moran.Moran_Local(self.y, w, keep_simulations=True, seed=SEED)
         # m4 = moran.Moran_Local_BV(self.x, self.y, self.w)
         np.testing.assert_allclose(m1.z, m3.z, atol=ATOL, rtol=RTOL)
 
@@ -344,27 +346,29 @@ class TestMoranLocal:
 
     @parametrize_desmith
     def test_defaults(self, w):
-        lm = moran.Moran_Local(
-            self.y,
-            w,
-            transformation="r",
-            permutations=99,
-            keep_simulations=True,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local(
+                self.y,
+                w,
+                transformation="r",
+                permutations=99,
+                keep_simulations=True,
+                seed=SEED,
+            )
         np.testing.assert_allclose(lm.z_sim[0], -0.6990291160835514)
         np.testing.assert_allclose(lm.p_z_sim[0], 0.24226691753791396)
 
     @parametrize_sac
     def test_labels(self, w):
-        lm = moran.Moran_Local(
-            sac1.HSG_VAL.values,
-            w,
-            transformation="r",
-            permutations=99,
-            keep_simulations=True,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local(
+                sac1.HSG_VAL.values,
+                w,
+                transformation="r",
+                permutations=99,
+                keep_simulations=True,
+                seed=SEED,
+            )
         expected_labels = np.array(
             [
                 "High-High",
@@ -387,14 +391,15 @@ class TestMoranLocal:
 
     @parametrize_sac
     def test_explore(self, w):
-        lm = moran.Moran_Local(
-            sac1.HSG_VAL.values,
-            w,
-            transformation="r",
-            permutations=99,
-            keep_simulations=True,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local(
+                sac1.HSG_VAL.values,
+                w,
+                transformation="r",
+                permutations=99,
+                keep_simulations=True,
+                seed=SEED,
+            )
         m = lm.explore(sac1)
         np.testing.assert_array_equal(
             m.get_bounds(),
@@ -423,14 +428,15 @@ class TestMoranLocal:
 
         matplotlib.use("Agg")
 
-        lm = moran.Moran_Local(
-            sac1.HSG_VAL.values,
-            w,
-            transformation="r",
-            permutations=99,
-            keep_simulations=True,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local(
+                sac1.HSG_VAL.values,
+                w,
+                transformation="r",
+                permutations=99,
+                keep_simulations=True,
+                seed=SEED,
+            )
         ax = lm.plot(sac1)
 
         if GPD_GE_120:
@@ -473,14 +479,15 @@ class TestMoranLocal:
 
         matplotlib.use("Agg")
 
-        lm = moran.Moran_Local(
-            sac1.WHITE,
-            w,
-            transformation="r",
-            permutations=99,
-            keep_simulations=True,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local(
+                sac1.WHITE,
+                w,
+                transformation="r",
+                permutations=99,
+                keep_simulations=True,
+                seed=SEED,
+            )
 
         ax = lm.plot_scatter()
 
@@ -520,14 +527,15 @@ class TestMoranLocal:
 
         matplotlib.use("Agg")
 
-        lm = moran.Moran_Local(
-            sac1.WHITE,
-            w,
-            transformation="r",
-            permutations=99,
-            keep_simulations=True,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local(
+                sac1.WHITE,
+                w,
+                transformation="r",
+                permutations=99,
+                keep_simulations=True,
+                seed=SEED,
+            )
 
         ax = lm.plot_scatter(
             crit_value=None,
@@ -550,15 +558,16 @@ class TestMoranLocal:
 
     @parametrize_desmith
     def test_parallel(self, w):
-        lm = moran.Moran_Local(
-            self.y,
-            w,
-            transformation="r",
-            n_jobs=-1,
-            permutations=99,
-            keep_simulations=True,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local(
+                self.y,
+                w,
+                transformation="r",
+                n_jobs=-1,
+                permutations=99,
+                keep_simulations=True,
+                seed=SEED,
+            )
         np.testing.assert_allclose(lm.z_sim[0], -0.6990291160835514)
         np.testing.assert_allclose(lm.p_z_sim[0], 0.24226691753791396)
 
@@ -654,14 +663,15 @@ class TestMoranLocal:
 
         matplotlib.use("Agg")
 
-        lm = moran.Moran_Local(
-            sac1.WHITE,
-            w,
-            transformation="r",
-            permutations=99,
-            keep_simulations=True,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local(
+                sac1.WHITE,
+                w,
+                transformation="r",
+                permutations=99,
+                keep_simulations=True,
+                seed=SEED,
+            )
         axs = lm.plot_combination(
             sac1,
             "WHITE",
@@ -709,15 +719,16 @@ class TestMoranLocalBV:
 
     @parametrize_sids
     def test_defaults(self, w):
-        lm = moran.Moran_Local_BV(
-            self.x,
-            self.y,
-            w,
-            keep_simulations=True,
-            transformation="r",
-            permutations=99,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local_BV(
+                self.x,
+                self.y,
+                w,
+                keep_simulations=True,
+                transformation="r",
+                permutations=99,
+                seed=SEED,
+            )
         np.testing.assert_allclose(lm.Is[0], 1.4649221250620736)
         np.testing.assert_allclose(lm.z_sim[0], 1.330673752886702)
         np.testing.assert_allclose(lm.p_z_sim[0], 0.09164819151535242)
@@ -747,15 +758,16 @@ class TestMoranLocalBV:
 
     @parametrize_sids
     def test_labels(self, w):
-        lm = moran.Moran_Local_BV(
-            self.x,
-            self.y,
-            w,
-            transformation="r",
-            permutations=99,
-            keep_simulations=True,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local_BV(
+                self.x,
+                self.y,
+                w,
+                transformation="r",
+                permutations=99,
+                keep_simulations=True,
+                seed=SEED,
+            )
         expected_labels = np.array(
             [
                 "Insignificant",
@@ -778,15 +790,16 @@ class TestMoranLocalBV:
 
     @parametrize_sids
     def test_explore(self, w):
-        lm = moran.Moran_Local_BV(
-            self.x,
-            self.y,
-            w,
-            transformation="r",
-            permutations=99,
-            keep_simulations=True,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local_BV(
+                self.x,
+                self.y,
+                w,
+                transformation="r",
+                permutations=99,
+                keep_simulations=True,
+                seed=SEED,
+            )
         m = lm.explore(self.gdf)
         np.testing.assert_array_equal(
             m.get_bounds(),
@@ -818,15 +831,16 @@ class TestMoranLocalBV:
 
         matplotlib.use("Agg")
 
-        lm = moran.Moran_Local_BV(
-            self.x,
-            self.y,
-            w,
-            transformation="r",
-            permutations=99,
-            keep_simulations=True,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local_BV(
+                self.x,
+                self.y,
+                w,
+                transformation="r",
+                permutations=99,
+                keep_simulations=True,
+                seed=SEED,
+            )
         ax = lm.plot(self.gdf)
 
         if GPD_GE_120:
@@ -867,15 +881,16 @@ class TestMoranLocalBV:
 
         matplotlib.use("Agg")
 
-        lm = moran.Moran_Local_BV(
-            self.x,
-            self.y,
-            w,
-            transformation="r",
-            permutations=99,
-            keep_simulations=True,
-            seed=SEED,
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local_BV(
+                self.x,
+                self.y,
+                w,
+                transformation="r",
+                permutations=99,
+                keep_simulations=True,
+                seed=SEED,
+            )
         axs = lm.plot_combination(
             self.gdf,
             "SIDR79",
@@ -902,9 +917,10 @@ class TestMoranLocalRate:
 
     @parametrize_sids
     def test_moran_rate(self, w):
-        lm = moran.Moran_Local_Rate(
-            self.e, self.b, w, transformation="r", permutations=99, seed=SEED
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local_Rate(
+                self.e, self.b, w, transformation="r", permutations=99, seed=SEED
+            )
         np.testing.assert_allclose(lm.z_sim[0], 0.02702781851384379, 7)
         np.testing.assert_allclose(lm.p_z_sim[0], 0.4892187730835096)
 

--- a/esda/tests/test_shape.py
+++ b/esda/tests/test_shape.py
@@ -317,7 +317,14 @@ def test_mir_with_regions_and_ref_pts():
 
 
 def test_second_areal_moment():
-    observed = esda.shape.second_areal_moment(testbench.geometry)
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            "`second_areal_moment` is deprecated and "
+            "will be removed in a future version"
+        ),
+    ):
+        observed = esda.shape.second_areal_moment(testbench.geometry)
     testing.assert_allclose(
         observed,
         [0.23480628, 0.11458333, 1.57459077, 1.58210246, 14.18946959],
@@ -326,7 +333,20 @@ def test_second_areal_moment():
 
 
 def test_moa():
-    observed = esda.shape.moa_ratio(shape)
+    with (
+        pytest.warns(
+            DeprecationWarning,
+            match=(
+                "`second_areal_moment` is deprecated and "
+                "will be removed in a future version"
+            ),
+        ),
+        pytest.warns(
+            DeprecationWarning,
+            match="`moa_ratio` is deprecated and will be removed in a future version.",
+        ),
+    ):
+        observed = esda.shape.moa_ratio(shape)
     testing.assert_allclose(observed, 5.35261, atol=ATOL)
 
 

--- a/esda/tests/test_significance.py
+++ b/esda/tests/test_significance.py
@@ -10,7 +10,9 @@ coordinates = numpy.random.random(size=(800, 2))
 x = numpy.random.normal(size=(800,))
 w = Voronoi(coordinates, clip="bounding_box", use_index=False)
 w.transform = "r"
-stat = esda.Moran_Local(x, w, permutations=19)
+
+with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+    stat = esda.Moran_Local(x, w, permutations=19)
 
 
 @pytest.mark.parametrize(

--- a/esda/tests/test_util.py
+++ b/esda/tests/test_util.py
@@ -12,8 +12,9 @@ class TestFdr:
         self.y = np.array(f.by_col["HR8893"])
 
     def test_fdr(self):
-        lm = moran.Moran_Local(
-            self.y, self.w, transformation="r", permutations=999, seed=10
-        )
+        with pytest.WARN_ALT_HYPOTHESIS_DEPR:
+            lm = moran.Moran_Local(
+                self.y, self.w, transformation="r", permutations=999, seed=10
+            )
         assert pytest.approx(util.fdr(lm.p_sim, 0.1)) == 0.002564102564102564
         assert pytest.approx(util.fdr(lm.p_sim, 0.05)) == 0.001282051282051282


### PR DESCRIPTION
### Handle more CI warnings CI – [2026-05-02]

* resolve row stack warning thrown by numpy from inside codebase itself
  * resolves #429 
* catch warning is CI
  * new MOA naming
  * G* warning
  * Alternate hypothesis warning   
* Also we were not actually installing the development version of `esda` during CI... 😬 

--------------------------

* warnings in `dev` down from [103](https://github.com/pysal/esda/actions/runs/25255035399/job/74052927205#step:6:520) to [12](https://github.com/pysal/esda/actions/runs/25262400397/job/74071739695?pr=475#step:7:468)