### PR TITLE
BUG:  Moran_Local p_sim calculation should use crand

### DIFF
--- a/esda/moran.py
+++ b/esda/moran.py
@@ -21,6 +21,7 @@ from scipy import sparse
 from .crand import _prepare_univariate
 from .crand import crand as _crand_plus
 from .crand import njit as _njit
+from .significance import calculate_significance
 from .smoothing import assuncao_rate
 from .tabular import _bivariate_handler, _univariate_handler
 
@@ -1354,6 +1355,7 @@ class Moran_Local:
         self.__quads()
         self.__moments()
         if permutations:
+            effective_alternative = "directed" if alternative is None else alternative
             self.p_sim, self.rlisas = _crand_plus(
                 z,
                 w,
@@ -1368,11 +1370,11 @@ class Moran_Local:
             self.sim = np.transpose(self.rlisas)
             if keep_simulations:
                 sim = np.transpose(self.rlisas)
-                above = sim >= self.Is
-                larger = above.sum(0)
-                low_extreme = (self.permutations - larger) < larger
-                larger[low_extreme] = self.permutations - larger[low_extreme]
-                self.p_sim = (larger + 1.0) / (permutations + 1.0)
+                self.p_sim = calculate_significance(
+                    self.Is,
+                    self.rlisas,
+                    alternative=effective_alternative,
+                )
                 self.sim = sim
                 self.EI_sim = self.sim.mean(axis=0)
                 self.seI_sim = self.sim.std(axis=0)
@@ -1844,6 +1846,7 @@ class Moran_Local_BV:
         self.quads = quads
         self.__quads()
         if permutations:
+            effective_alternative = "directed" if alternative is None else alternative
             self.p_sim, self.rlisas = _crand_plus(
                 np.column_stack((zx, zy)),
                 w,
@@ -1858,11 +1861,11 @@ class Moran_Local_BV:
             self.sim = np.transpose(self.rlisas)
             if keep_simulations:
                 sim = np.transpose(self.rlisas)
-                above = sim >= self.Is
-                larger = above.sum(0)
-                low_extreme = (self.permutations - larger) < larger
-                larger[low_extreme] = self.permutations - larger[low_extreme]
-                self.p_sim = (larger + 1.0) / (permutations + 1.0)
+                self.p_sim = calculate_significance(
+                    self.Is,
+                    self.rlisas,
+                    alternative=effective_alternative,
+                )
                 self.sim = sim
                 self.EI_sim = sim.mean(axis=0)
                 self.seI_sim = sim.std(axis=0)

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -358,6 +358,41 @@ class TestMoranLocal:
         np.testing.assert_allclose(lm.z_sim[0], -0.6990291160835514)
         np.testing.assert_allclose(lm.p_z_sim[0], 0.24226691753791396)
 
+    @parametrize_desmith
+    def test_alternative_respected_with_kept_simulations(self, w):
+        kwargs = dict(
+            y=self.y,
+            w=w,
+            transformation="r",
+            permutations=99,
+            seed=SEED,
+        )
+
+        directed_keep = moran.Moran_Local(
+            **kwargs,
+            keep_simulations=True,
+            alternative="directed",
+        )
+        directed_drop = moran.Moran_Local(
+            **kwargs,
+            keep_simulations=False,
+            alternative="directed",
+        )
+        two_sided_keep = moran.Moran_Local(
+            **kwargs,
+            keep_simulations=True,
+            alternative="two-sided",
+        )
+        two_sided_drop = moran.Moran_Local(
+            **kwargs,
+            keep_simulations=False,
+            alternative="two-sided",
+        )
+
+        np.testing.assert_allclose(directed_keep.p_sim, directed_drop.p_sim)
+        np.testing.assert_allclose(two_sided_keep.p_sim, two_sided_drop.p_sim)
+        assert not np.allclose(directed_keep.p_sim, two_sided_keep.p_sim)
+
     @parametrize_sac
     def test_labels(self, w):
         with pytest.WARN_ALT_HYPOTHESIS_DEPR:
@@ -732,6 +767,42 @@ class TestMoranLocalBV:
         np.testing.assert_allclose(lm.Is[0], 1.4649221250620736)
         np.testing.assert_allclose(lm.z_sim[0], 1.330673752886702)
         np.testing.assert_allclose(lm.p_z_sim[0], 0.09164819151535242)
+
+    @parametrize_sids
+    def test_alternative_respected_with_kept_simulations(self, w):
+        kwargs = dict(
+            x=self.x,
+            y=self.y,
+            w=w,
+            transformation="r",
+            permutations=99,
+            seed=SEED,
+        )
+
+        directed_keep = moran.Moran_Local_BV(
+            **kwargs,
+            keep_simulations=True,
+            alternative="directed",
+        )
+        directed_drop = moran.Moran_Local_BV(
+            **kwargs,
+            keep_simulations=False,
+            alternative="directed",
+        )
+        two_sided_keep = moran.Moran_Local_BV(
+            **kwargs,
+            keep_simulations=True,
+            alternative="two-sided",
+        )
+        two_sided_drop = moran.Moran_Local_BV(
+            **kwargs,
+            keep_simulations=False,
+            alternative="two-sided",
+        )
+
+        np.testing.assert_allclose(directed_keep.p_sim, directed_drop.p_sim)
+        np.testing.assert_allclose(two_sided_keep.p_sim, two_sided_drop.p_sim)
+        assert not np.allclose(directed_keep.p_sim, two_sided_keep.p_sim)
 
     @pytest.mark.skip("This function is being deprecated in the next release.")
     def test_by_col(self):


### PR DESCRIPTION
Fixes #486 

@ljwolf I'd like to get you explicit approval here to check whether I can use `calculate_significance` in this way here.

 