### PR TITLE
DOC: properly expose LocalCrossPlot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,9 +239,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   and can be added to the global gitignore or merged into this file. However, if you prefer,
 #   you could uncomment the following to ignore the entire vscode folder
 .vscode/
 
@@ -297,3 +297,5 @@ tools/changelog_2.4.0.md
 # pixi environments
 .pixi/*
 !.pixi/config.toml
+
+docs/source/generated/

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -68,7 +68,7 @@ Inspection plots
 .. autosummary::
    :toctree: generated/
 
-    esda.GIPlot
+    LocalCrossPlot
 
 .. _join_api:
 
@@ -112,7 +112,7 @@ Map Comparison
     homogeneity
     overlay_entropy
 
-    
+
 Mixture Smoothing
 -----------------
 
@@ -120,7 +120,7 @@ Mixture Smoothing
    :toctree: generated/
 
     NP_Mixture_Smoother
-    
+
 
 Modifiable Areal Unit Tests
 ---------------------------


### PR DESCRIPTION
I forgot to update that when we changed the name.