### PR TITLE
ENH: warn when the Moran family receives an ill-defined (disconnected) graph

### DIFF
--- a/esda/moran.py
+++ b/esda/moran.py
@@ -24,6 +24,7 @@ from .crand import njit as _njit
 from .significance import calculate_significance
 from .smoothing import assuncao_rate
 from .tabular import _bivariate_handler, _univariate_handler
+from .util import warn_if_disconnected
 
 __all__ = [
     "Moran",
@@ -186,6 +187,7 @@ class Moran:
         self.y = y
         w = _transform(w, transformation)
         self.w = w
+        warn_if_disconnected(w, "Moran's I")
         self.permutations = permutations
         self.__moments()
         self.I = self.__calc(self.z)
@@ -546,6 +548,7 @@ class Moran_BV:
         self.den = n - 1.0  # zx'zx = zy'zy = n-1
         w = _transform(w, transformation)
         self.w = w
+        warn_if_disconnected(w, "Bivariate Moran's I")
         self.I = self.__calc(zy)
         if permutations:
             nrp = np.random.permutation
@@ -1359,6 +1362,7 @@ class Moran_Local:
         self.z = z
         w = _transform(w, transformation)
         self.w = w
+        warn_if_disconnected(w, "Local Moran's I")
         self.permutations = permutations
         self.den = (z * z).sum()
         self.Is = self.__calc(self.w, self.z)

--- a/esda/tests/test_moran.py
+++ b/esda/tests/test_moran.py
@@ -1,3 +1,5 @@
+import warnings
+
 import geopandas as gpd
 import libpysal
 import numpy as np
@@ -1051,6 +1053,141 @@ class TestMoranLocalRate:
         )
         np.testing.assert_allclose(lm["SID79-BIR79_z_sim"][0], 0.02702781851384379, 7)
         np.testing.assert_allclose(lm["SID79-BIR79_p_z_sim"][0], 0.4892187730835096)
+
+
+def _w_with_islands():
+    # nodes 0 and 1 are connected; nodes 2 and 3 are isolates, so the graph
+    # has multiple disconnected components and is ill-defined for Moran's I.
+    neighbors = {0: [1], 1: [0], 2: [], 3: []}
+    weights = {0: [1.0], 1: [1.0], 2: [], 3: []}
+    return libpysal.weights.W(neighbors, weights, silence_warnings=True)
+
+
+def _w_single_island():
+    # nodes 0, 1, 2 are connected; node 3 is the only isolate, exercising the
+    # singular "1 island" branch of the warning message.
+    neighbors = {0: [1], 1: [0, 2], 2: [1], 3: []}
+    weights = {0: [1.0], 1: [1.0, 1.0], 2: [1.0], 3: []}
+    return libpysal.weights.W(neighbors, weights, silence_warnings=True)
+
+
+def _w_two_clusters():
+    # two disconnected connected pairs and no isolates: n_components > 1 while
+    # n_islands == 0, so neither island branch of the message fires.
+    neighbors = {0: [1], 1: [0], 2: [3], 3: [2]}
+    weights = {0: [1.0], 1: [1.0], 2: [1.0], 3: [1.0]}
+    return libpysal.weights.W(neighbors, weights, silence_warnings=True)
+
+
+parametrize_ill_defined = pytest.mark.parametrize(
+    "w",
+    [
+        _w_with_islands(),
+        libpysal.graph.Graph.from_W(_w_with_islands()),
+    ],
+    ids=["W", "Graph"],
+)
+
+parametrize_single_island = pytest.mark.parametrize(
+    "w",
+    [
+        _w_single_island(),
+        libpysal.graph.Graph.from_W(_w_single_island()),
+    ],
+    ids=["W", "Graph"],
+)
+
+parametrize_two_clusters = pytest.mark.parametrize(
+    "w",
+    [
+        _w_two_clusters(),
+        libpysal.graph.Graph.from_W(_w_two_clusters()),
+    ],
+    ids=["W", "Graph"],
+)
+
+parametrize_connected = pytest.mark.parametrize(
+    "w",
+    [
+        libpysal.weights.util.lat2W(3, 3),
+        libpysal.graph.Graph.from_W(libpysal.weights.util.lat2W(3, 3)),
+    ],
+    ids=["W", "Graph"],
+)
+
+
+class TestIllDefinedGraphWarning:
+    """Moran statistics should warn when the graph is not fully connected."""
+
+    @parametrize_ill_defined
+    def test_moran_warns(self, w):
+        y = np.array([1.0, 2.0, 3.0, 4.0])
+        with pytest.warns(UserWarning, match="not fully connected"):
+            moran.Moran(y, w, permutations=0)
+
+    @parametrize_ill_defined
+    def test_moran_bv_warns(self, w):
+        x = np.array([4.0, 3.0, 2.0, 1.0])
+        y = np.array([1.0, 2.0, 3.0, 4.0])
+        with pytest.warns(UserWarning, match="not fully connected"):
+            moran.Moran_BV(x, y, w, permutations=0)
+
+    @parametrize_ill_defined
+    def test_moran_local_warns(self, w):
+        y = np.array([1.0, 2.0, 3.0, 4.0])
+        with pytest.warns(UserWarning, match="not fully connected"):
+            moran.Moran_Local(y, w, permutations=0)
+
+    @parametrize_ill_defined
+    def test_moran_rate_warns(self, w):
+        e = np.array([10.0, 20.0, 30.0, 40.0])
+        b = np.array([100.0, 100.0, 100.0, 100.0])
+        with pytest.warns(UserWarning, match="not fully connected"):
+            moran.Moran_Rate(e, b, w, permutations=0)
+
+    @parametrize_ill_defined
+    def test_moran_local_rate_warns(self, w):
+        e = np.array([10.0, 20.0, 30.0, 40.0])
+        b = np.array([100.0, 100.0, 100.0, 100.0])
+        with pytest.warns(UserWarning, match="not fully connected"):
+            moran.Moran_Local_Rate(e, b, w, permutations=0)
+
+    @parametrize_single_island
+    def test_moran_warns_single_island(self, w):
+        # n_islands == 1: the singular "1 island" message branch.
+        y = np.array([1.0, 2.0, 3.0, 4.0])
+        with pytest.warns(UserWarning, match="1 island with id"):
+            moran.Moran(y, w, permutations=0)
+
+    @parametrize_two_clusters
+    def test_moran_warns_two_clusters_no_islands(self, w):
+        # n_components > 1 with n_islands == 0: neither island branch fires.
+        y = np.array([1.0, 2.0, 3.0, 4.0])
+        with pytest.warns(UserWarning, match="2 disconnected components") as record:
+            moran.Moran(y, w, permutations=0)
+        assert all("island" not in str(r.message) for r in record)
+
+    @parametrize_connected
+    def test_moran_no_warning_when_connected(self, w):
+        y = np.arange(1, 10, dtype=float)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            moran.Moran(y, w, permutations=0)
+
+    @parametrize_connected
+    def test_moran_bv_no_warning_when_connected(self, w):
+        x = np.arange(1, 10, dtype=float)
+        y = np.arange(9, 0, -1, dtype=float)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            moran.Moran_BV(x, y, w, permutations=0)
+
+    @parametrize_connected
+    def test_moran_local_no_warning_when_connected(self, w):
+        y = np.arange(1, 10, dtype=float)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            moran.Moran_Local(y, w, permutations=0)
 
 
 def _fetch_map_string(m):

--- a/esda/util.py
+++ b/esda/util.py
@@ -1,4 +1,61 @@
+import warnings
+
 import numpy as np
+from libpysal.weights import W
+
+
+def _islands(w):
+    """Return the ids of isolated observations for a ``W`` or ``Graph``."""
+    if isinstance(w, W):
+        return list(w.islands)
+    return list(w.isolates)
+
+
+def warn_if_disconnected(w, stat="The statistic"):
+    """Warn when the spatial graph is not fully connected.
+
+    Statistics in the Moran family (and several others) are only well defined
+    on a fully connected graph. When ``w`` has isolates or more than one
+    connected component the resulting value is not interpretable and can fall
+    outside its usual bounds (e.g. Moran's :math:`I` outside ``[-1, 1]``). This
+    mirrors the connectivity check ``libpysal``'s ``W`` performs on
+    construction, but is run at the point of use so it also covers ``Graph``,
+    which does not warn on its own (see ``pysal/libpysal#807``).
+
+    Parameters
+    ----------
+    w : libpysal.weights.W or libpysal.graph.Graph
+        The spatial weights or graph used by the statistic.
+    stat : str, optional
+        Name of the statistic, used in the warning message. Default is
+        ``"The statistic"``.
+
+    Notes
+    -----
+    The check is a no-op for a fully connected graph
+    (``w.n_components == 1``). Both ``W`` and ``Graph`` count isolates as
+    singleton components, so ``n_components > 1`` also captures the
+    isolates-only case.
+    """
+    if w.n_components <= 1:
+        return
+
+    message = (
+        "The spatial graph is not fully connected: "
+        f"\n There are {w.n_components} disconnected components."
+    )
+    islands = _islands(w)
+    n_islands = len(islands)
+    if n_islands == 1:
+        message += f"\n There is 1 island with id: {islands[0]}."
+    elif n_islands > 1:
+        ids = ", ".join(str(island) for island in islands)
+        message += f"\n There are {n_islands} islands with ids: {ids}."
+    message += (
+        f"\n {stat} is not well defined for graphs that are not fully "
+        "connected and the resulting value may fall outside its usual bounds."
+    )
+    warnings.warn(message, UserWarning, stacklevel=3)
 
 
 def fdr(pvalues, alpha=0.05):


### PR DESCRIPTION
ENH: warn when the Moran family receives an ill-defined (disconnected) graph

## What

Adds a shared connectivity check, `warn_if_disconnected`, in `esda/util.py` and
wires it into `Moran`, `Moran_BV`, and `Moran_Local`. When the supplied graph is
not fully connected (isolates and/or more than one connected component) the
statistic now emits a `UserWarning` explaining that the result is not
well defined and may fall outside its usual bounds.

## Why

Per pysal/libpysal#807 the team agreed that `Graph` should not warn about
connectivity on its own, and that these checks belong in the consuming
use-cases. `W` already warns on construction, but `Graph` does not, so a graph
with many isolates silently flows through `Moran` and friends. The returned `I`
is then uninterpretable and can leave the `[-1, 1]` interval. For example, two
connected observations with extreme values plus twenty isolates yields
`Moran(y, graph).I == 9.996` with no warning at all.

Running the check at the point of use covers both `W` and `Graph` (both expose
`n_components`; isolates are accessed via `W.islands` / `Graph.isolates`,
mirroring the idiom already used in `join_counts.py` and `silhouettes.py`). The
message mirrors the wording of libpysal's own `W` connectivity warning for
consistency.

## Scope

This first cut covers the Moran family only. `Moran_Rate` and
`Moran_Local_Rate` inherit the check for free through their `super().__init__`
calls. `Moran_Local_BV`, and the Geary and Getis-Ord statistics, can be routed
through the same helper in a follow-up if desired.

## A note on `stacklevel`

The warning uses `stacklevel=3`, which points at the user call site for the
base estimators (`Moran`, `Moran_BV`, `Moran_Local`). The `Rate` subclasses add
one extra frame (`Moran_Rate.__init__` -> `Moran.__init__` -> the helper), so
for those the warning is attributed to the subclass `__init__` rather than the
caller. Making attribution exact for every entry point would mean passing a
per-class `stacklevel` down to the helper, which trades complexity for a
cosmetic change to the traceback line. The warning text is identical and correct
in every case, so this is left as-is.

## Testing

`esda/tests/test_moran.py::TestIllDefinedGraphWarning` covers, for both `W` and
`Graph` inputs:

- `pytest.warns(UserWarning)` on an ill-defined graph for `Moran`, `Moran_BV`,
  `Moran_Local`, `Moran_Rate`, and `Moran_Local_Rate` (the last two pin the
  inherited check rather than assuming it).
- the single-isolate case (`n_islands == 1`), exercising the singular
  "1 island" message branch.
- two disconnected clusters with no isolates (`n_components > 1`,
  `n_islands == 0`), the branch where neither island message fires.
- no warning on a fully connected lattice (`warnings.simplefilter("error")`)
  for `Moran`, `Moran_BV`, and `Moran_Local`.

Revert proof: with the tests in place, neutralizing the helper makes the
fourteen "warns" cases fail with `DID NOT WARN` while the no-warning cases keep
passing. The full `test_moran.py` module passes (74 passed, 9 skipped), run
three times for stability.

Closes #425
