### PR TITLE
fix: use robust pseudo p-value for two-sided significance

### DIFF
--- a/esda/significance.py
+++ b/esda/significance.py
@@ -85,20 +85,15 @@ def _permutation_significance(
             p_permutations + 1
         )
     elif alternative == "two-sided":
-        # find percentile p at which the test statistic sits
-        # find "synthetic" test statistic at 1-p
-        # count how many observations are outisde of (p, 1-p)
-        # including the test statistic and its synthetic pair
-        lows = np.empty(n_samples).astype(reference_distribution.dtype)
-        highs = np.empty(n_samples).astype(reference_distribution.dtype)
-        for i in range(n_samples):
-            percentile_i = (reference_distribution[i] <= test_stat[i]).mean() * 100
-            p_low = np.minimum(percentile_i, 100 - percentile_i)
-            lows[i] = np.percentile(reference_distribution[i], p_low)
-            highs[i] = np.percentile(reference_distribution[i], 100 - p_low)
-        n_outside = (reference_distribution <= lows[:, None]).sum(axis=1)
-        n_outside += (reference_distribution >= highs[:, None]).sum(axis=1)
-        p_value = (n_outside + 1) / (p_permutations + 1)
+        # use the robust pseudo p-value rather than percentiles. Percentiles
+        # are degenerate when the reference distribution is constant, which
+        # makes the percentile-based count exceed p_permutations and yields a
+        # p-value greater than one.
+        greater = (reference_distribution >= test_stat).sum(axis=1)
+        lesser = (reference_distribution <= test_stat).sum(axis=1)
+        p_value = np.minimum(
+            2 * (np.minimum(greater, lesser) + 1) / (p_permutations + 1), 1.0
+        )
     elif alternative == "folded":
         means = np.empty((n_samples, 1)).astype(reference_distribution.dtype)
         for i in range(n_samples):

--- a/esda/tests/test_significance.py
+++ b/esda/tests/test_significance.py
@@ -52,3 +52,51 @@ def test_alternative_relationships():
         "Directed p-values should tend to be much "
         "smaller than two_sided p-values or folded p-values."
     )
+
+
+def test_two_sided_degenerate_null():
+    # GH #504: a constant reference distribution makes the percentile-based
+    # two-sided p-value degenerate. With the test statistic equal to the
+    # constant, every permutation lands in both tails, so the old percentile
+    # count was 2 * p_permutations and produced 1.95. The clipped pseudo
+    # p-value is exactly one here.
+    reference = numpy.full((1, 19), 5.0)
+    degenerate = calculate_significance(5.0, reference, alternative="two-sided")
+    numpy.testing.assert_allclose(degenerate, 1.0)
+
+    reference = numpy.full((3, 19), 2.0)
+    degenerate = calculate_significance(
+        numpy.full(3, 2.0), reference, alternative="two-sided"
+    )
+    numpy.testing.assert_allclose(degenerate, numpy.ones(3))
+
+
+def test_two_sided_degenerate_null_off_constant():
+    # The second failure mode of the old percentile formula: a constant
+    # reference distribution with the test statistic away from the constant.
+    # The lower percentile collapsed to the constant, so both tail counts
+    # again covered the whole distribution and the p-value exceeded one. The
+    # pseudo p-value here counts only the side the constant falls on:
+    # greater = 19, lesser = 0, so 2 * (0 + 1) / 20 = 0.1.
+    reference = numpy.full((1, 19), 5.0)
+    p_value = calculate_significance(3.0, reference, alternative="two-sided")
+    numpy.testing.assert_allclose(p_value, 0.1)
+
+
+def test_two_sided_non_degenerate_null():
+    numpy.random.seed(2478879)
+    reference = numpy.random.normal(size=(1, 999))
+    # greater = 7, lesser = 992, so 2 * (7 + 1) / 1000 = 0.016.
+    p_value = calculate_significance(2.5, reference, alternative="two-sided")
+    numpy.testing.assert_allclose(p_value, 0.016)
+
+
+def test_two_sided_is_twice_directed_one_sided():
+    # On a clearly one-sided statistic (well into the upper tail) the directed
+    # p-value picks the smaller tail, so the two-sided value is exactly twice
+    # the directed value as long as the clip at one does not bind.
+    numpy.random.seed(2478879)
+    reference = numpy.random.normal(size=(1, 999))
+    two_sided = calculate_significance(2.5, reference, alternative="two-sided")
+    directed = calculate_significance(2.5, reference, alternative="directed")
+    numpy.testing.assert_allclose(two_sided, 2 * directed)


### PR DESCRIPTION
## Title

fix: use robust pseudo p-value for two-sided significance

## Summary

The two-sided branch of `_permutation_significance` in `esda/significance.py`
derived the p-value from percentiles of the reference distribution. When the
conditional reference distribution is constant (every permuted value is
identical), those percentiles collapse to a single value, so both the lower and
upper tail counts include the entire reference distribution. The resulting count
exceeds `p_permutations`, and the p-value can exceed one.

```python
>>> import numpy as np
>>> from esda.significance import calculate_significance
>>> calculate_significance(5.0, np.full((1, 19), 5.0), alternative="two-sided")
1.95
```

This replaces the percentile approach with the equivalent robust pseudo
p-value suggested in the issue:

```
2 * (min(greater, lesser) + 1) / (permutations + 1)
```

clipped at one. The result stays in `(0, 1]` for degenerate nulls and matches
the existing one-sided counting conventions used by the `greater`/`lesser`
branches, so the `directed <= two-sided` invariant still holds.

## Changes

- `esda/significance.py`: two-sided branch now uses the clipped pseudo p-value.
- `esda/tests/test_significance.py`: regression tests covering
  - the degenerate constant null with the statistic on the constant, asserting
    the result is exactly `1.0` for both the scalar and vector inputs;
  - the second failure mode of the old formula, a constant null with the
    statistic off the constant, asserting the pseudo p-value `0.1`;
  - a seeded normal null, asserting the exact pseudo p-value `0.016`;
  - the `two-sided == 2 * directed` identity on a one-sided statistic.

## Testing

- `pytest esda/tests/test_significance.py` passes (10 tests), including the
  existing `test_execution_and_range` and `test_alternative_relationships`.
- Each new assertion fails on the unpatched source (the degenerate scalar case
  reports `1.95`) and passes with the fix.
- Broad regression on the consumers of the function
  (`test_moran.py`, `test_moran_local_mv.py`) passes.

Closes #504
